### PR TITLE
Part 3 of X: Add passing Pending->Succeeded test

### DIFF
--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -2,10 +2,13 @@ package taskruntoolcall
 
 import (
 	"context"
+	"time"
 
 	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+	"github.com/humanlayer/smallchain/kubechain/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -45,6 +48,51 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			Expect(updatedTRTC.Status.Status).To(Equal("Pending"))
 			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Initializing"))
 			Expect(updatedTRTC.Status.StartTime).NotTo(BeNil())
+		})
+	})
+
+	Context("Pending -> Succeeded", func() {
+		It("moves to Succeeded after executing a simple function tool call", func() {
+			ctx := context.Background()
+
+			teardown := setupTestAddTool(ctx)
+			defer teardown()
+
+			// Create TaskRunToolCall with Pending status
+			taskRunToolCall := trtcForAddTool.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
+				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
+				Status:       "Pending",
+				StatusDetail: "Ready for execution",
+				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+			})
+
+			By("reconciling the trtc")
+			reconciler, recorder := reconciler()
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      taskRunToolCall.Name,
+					Namespace: taskRunToolCall.Namespace,
+				},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the taskruntoolcall status has changed to Succeeded")
+			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      taskRunToolCall.Name,
+				Namespace: taskRunToolCall.Namespace,
+			}, updatedTRTC)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
+			Expect(updatedTRTC.Status.Result).To(Equal("5")) // 2 + 3 = 5
+			Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
+			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Tool executed successfully"))
+
+			By("checking that execution events were emitted")
+			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
 		})
 	})
 })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add test for `Pending -> Succeeded` transition in `taskruntoolcall_controller_test.go`, verifying status change and event emission.
> 
>   - **Test Addition**:
>     - Adds a test case in `taskruntoolcall_controller_test.go` for `Pending -> Succeeded` transition.
>     - Sets up `TaskRunToolCall` with `Pending` status and executes a simple function.
>     - Verifies status changes to `Succeeded` and result is `5`.
>     - Checks for event emission of `ExecutionSucceeded`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 3b8d0277d2f7135cbc5c9c08234bb9b48a044439. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->