### PR TITLE
port 0 to avoid 8080 conflict

### DIFF
--- a/kubechain/internal/controller/mcpserver/suite_test.go
+++ b/kubechain/internal/controller/mcpserver/suite_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -68,6 +69,9 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: ":0", // Use port 0 to let the system assign a free port
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change metrics server `BindAddress` to `":0"` in `suite_test.go` to avoid port 8080 conflicts.
> 
>   - **Behavior**:
>     - In `suite_test.go`, change metrics server `BindAddress` to `":0"` to allow the system to assign a free port, avoiding port 8080 conflicts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for e839a8246d6d6a1550528d975d3c5bea6a2c1c2c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->