### PR TITLE
4 of X: Pending -> Succeeded state with MCP Tool, no approval

### DIFF
--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -42,7 +42,7 @@ type TaskRunToolCallReconciler struct {
 	Scheme     *runtime.Scheme
 	recorder   record.EventRecorder
 	server     *http.Server
-	MCPManager *mcpmanager.MCPServerManager
+	MCPManager mcpmanager.MCPManagerInterface
 }
 
 func (r *TaskRunToolCallReconciler) webhookHandler(w http.ResponseWriter, req *http.Request) {

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -143,79 +143,80 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionFailed")
 		})
 
-		// Tests for MCP tools without approval requirement
-		Context("Pending -> Succeeded (MCP Tool)", func() {
-			It("successfully executes an MCP tool without requiring approval", func() {
-				// Setup MCP server without approval channel
-				testSecret.Setup(ctx)
-				mcpServer := &TestMCPServer{
-					name:                   "test-mcp-no-approval",
-					needsApproval:          false,
-					approvalContactChannel: "",
-				}
-				mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
-					Connected: true,
-					Status:    "Ready",
-				})
-				defer mcpServer.Teardown(ctx)
+	})
 
-				// Setup MCP tool
-				mcpTool := &TestMCPTool{
-					name:        "test-mcp-no-approval-tool",
-					mcpServer:   mcpServer.name,
-					mcpToolName: "test-tool",
-				}
-				tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
-					Ready:  true,
-					Status: "Ready",
-				})
-				defer mcpTool.Teardown(ctx)
+	// Tests for MCP tools without approval requirement
+	Context("Pending -> Succeeded (MCP Tool)", func() {
+		It("successfully executes an MCP tool without requiring approval", func() {
+			// Setup MCP server without approval channel
+			testSecret.Setup(ctx)
+			mcpServer := &TestMCPServer{
+				name:                   "test-mcp-no-approval",
+				needsApproval:          false,
+				approvalContactChannel: "",
+			}
+			mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
+				Connected: true,
+				Status:    "Ready",
+			})
+			defer mcpServer.Teardown(ctx)
 
-				// Create TaskRunToolCall with MCP tool reference
-				taskRunToolCall := &TestTaskRunToolCall{
-					name:      "test-mcp-no-approval-trtc",
-					toolName:  tool.Spec.Name,
-					arguments: `{"a": 2, "b": 3}`,
-				}
-				trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
-					Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
-					Status:       "Pending",
-					StatusDetail: "Ready for execution",
-					StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-				})
-				defer taskRunToolCall.Teardown(ctx)
+			// Setup MCP tool
+			mcpTool := &TestMCPTool{
+				name:        "test-mcp-no-approval-tool",
+				mcpServer:   mcpServer.name,
+				mcpToolName: "test-tool",
+			}
+			tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
+				Ready:  true,
+				Status: "Ready",
+			})
+			defer mcpTool.Teardown(ctx)
 
-				By("reconciling the taskruntoolcall that uses MCP tool without approval")
-				reconciler, recorder := reconciler()
+			// Create TaskRunToolCall with MCP tool reference
+			taskRunToolCall := &TestTaskRunToolCall{
+				name:      "test-mcp-no-approval-trtc",
+				toolName:  tool.Spec.Name,
+				arguments: `{"a": 2, "b": 3}`,
+			}
+			trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
+				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
+				Status:       "Pending",
+				StatusDetail: "Ready for execution",
+				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+			})
+			defer taskRunToolCall.Teardown(ctx)
 
-				reconciler.MCPManager = &MockMCPManager{
-					NeedsApproval: false, // This test specifically doesn't want approval
-				}
+			By("reconciling the taskruntoolcall that uses MCP tool without approval")
+			reconciler, recorder := reconciler()
 
-				_, err := reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      trtc.Name,
-						Namespace: trtc.Namespace,
-					},
-				})
+			reconciler.MCPManager = &MockMCPManager{
+				NeedsApproval: false, // This test specifically doesn't want approval
+			}
 
-				Expect(err).NotTo(HaveOccurred())
-
-				By("checking the taskruntoolcall status is set to Succeeded")
-				updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
-				err = k8sClient.Get(ctx, types.NamespacedName{
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
 					Name:      trtc.Name,
 					Namespace: trtc.Namespace,
-				}, updatedTRTC)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
-				Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
-				Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
-
-				By("checking that appropriate events were emitted")
-				utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
+				},
 			})
+
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the taskruntoolcall status is set to Succeeded")
+			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trtc.Name,
+				Namespace: trtc.Namespace,
+			}, updatedTRTC)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
+			Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
+			Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
+
+			By("checking that appropriate events were emitted")
+			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
 		})
 	})
 })

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -16,8 +16,6 @@ import (
 var _ = Describe("TaskRunToolCall Controller", func() {
 	Context("'' -> Pending", func() {
 		It("moves to Pending:Initializing", func() {
-			ctx := context.Background()
-
 			teardown := setupTestAddTool(ctx)
 			defer teardown()
 
@@ -93,6 +91,131 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 
 			By("checking that execution events were emitted")
 			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
+		})
+	})
+
+	Context("Pending -> Failed", func() {
+		It("fails when arguments are invalid", func() {
+			teardown := setupTestAddTool(ctx)
+			defer teardown()
+
+			// Create TaskRunToolCall with Pending status but invalid arguments
+			taskRunToolCall := &TestTaskRunToolCall{
+				name:      "invalid-args-trtc",
+				toolName:  addTool.name,
+				arguments: `invalid json`, // Invalid JSON
+			}
+			defer taskRunToolCall.Teardown(ctx)
+
+			trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
+				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
+				Status:       "Pending",
+				StatusDetail: "Ready for execution",
+				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+			})
+
+			By("reconciling the taskruntoolcall with invalid arguments")
+			reconciler, recorder := reconciler()
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      trtc.Name,
+					Namespace: trtc.Namespace,
+				},
+			})
+
+			// We expect an error during reconciliation
+			Expect(err).To(HaveOccurred())
+
+			By("checking the taskruntoolcall status is set to Error")
+			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trtc.Name,
+				Namespace: trtc.Namespace,
+			}, updatedTRTC)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedTRTC.Status.Status).To(Equal("Error"))
+			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Invalid arguments JSON"))
+			Expect(updatedTRTC.Status.Error).NotTo(BeEmpty())
+
+			By("checking that error events were emitted")
+			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionFailed")
+		})
+
+		// Tests for MCP tools without approval requirement
+		Context("Pending -> Succeeded (MCP Tool)", func() {
+			It("successfully executes an MCP tool without requiring approval", func() {
+				// Setup MCP server without approval channel
+				testSecret.Setup(ctx)
+				mcpServer := &TestMCPServer{
+					name:                   "test-mcp-no-approval",
+					needsApproval:          false,
+					approvalContactChannel: "",
+				}
+				mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
+					Connected: true,
+					Status:    "Ready",
+				})
+				defer mcpServer.Teardown(ctx)
+
+				// Setup MCP tool
+				mcpTool := &TestMCPTool{
+					name:        "test-mcp-no-approval-tool",
+					mcpServer:   mcpServer.name,
+					mcpToolName: "test-tool",
+				}
+				tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
+					Ready:  true,
+					Status: "Ready",
+				})
+				defer mcpTool.Teardown(ctx)
+
+				// Create TaskRunToolCall with MCP tool reference
+				taskRunToolCall := &TestTaskRunToolCall{
+					name:      "test-mcp-no-approval-trtc",
+					toolName:  tool.Spec.Name,
+					arguments: `{"a": 2, "b": 3}`,
+				}
+				trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
+					Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
+					Status:       "Pending",
+					StatusDetail: "Ready for execution",
+					StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+				})
+				defer taskRunToolCall.Teardown(ctx)
+
+				By("reconciling the taskruntoolcall that uses MCP tool without approval")
+				reconciler, recorder := reconciler()
+
+				reconciler.MCPManager = &MockMCPManager{
+					NeedsApproval: false, // This test specifically doesn't want approval
+				}
+
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      trtc.Name,
+						Namespace: trtc.Namespace,
+					},
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+
+				By("checking the taskruntoolcall status is set to Succeeded")
+				updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      trtc.Name,
+					Namespace: trtc.Namespace,
+				}, updatedTRTC)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
+				Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
+				Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
+
+				By("checking that appropriate events were emitted")
+				utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
+			})
 		})
 	})
 })

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -288,12 +288,6 @@ func (t *TestMCPServer) Teardown(ctx context.Context) {
 }
 
 // MockMCPManager is a struct that mocks the essential MCPServerManager functionality for testing
-// MCPManagerInterface defines the minimum interface our mock needs to implement
-type MCPManagerInterface interface {
-	CallTool(ctx context.Context, serverName, toolName string, args map[string]interface{}) (string, error)
-}
-
-// MockMCPManager is a struct that mocks the essential MCPServerManager functionality for testing
 type MockMCPManager struct {
 	NeedsApproval bool // Flag to control if mock MCP tools need approval
 }
@@ -368,10 +362,6 @@ func reconciler() (*TaskRunToolCallReconciler, *record.FakeRecorder) {
 	By("creating a test reconciler")
 	recorder := record.NewFakeRecorder(10)
 
-	mockManager := &MockMCPManager{
-		NeedsApproval: false,
-	}
-
 	reconciler := &TaskRunToolCallReconciler{
 		Client:   k8sClient,
 		Scheme:   k8sClient.Scheme(),
@@ -379,7 +369,9 @@ func reconciler() (*TaskRunToolCallReconciler, *record.FakeRecorder) {
 	}
 
 	// Set the MCPManager field directly using type assertion
-	reconciler.MCPManager = interface{}(mockManager).(MCPManagerInterface)
+	reconciler.MCPManager = &MockMCPManager{
+		NeedsApproval: false,
+	}
 
 	return reconciler, recorder
 }

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -19,23 +19,23 @@ var addTool = &TestTool{
 	toolType: "function",
 }
 
-var testContactChannel = &TestContactChannel{
-	name:        "test-contact-channel",
-	channelType: "slack",
-	secretName:  testSecret.name,
-}
+// var testContactChannel = &TestContactChannel{
+// 	name:        "test-contact-channel",
+// 	channelType: "slack",
+// 	secretName:  testSecret.name,
+// }
 
-var testMCPServer = &TestMCPServer{
-	name:                   "test-mcp-server",
-	needsApproval:          true,
-	approvalContactChannel: testContactChannel.name,
-}
+// var testMCPServer = &TestMCPServer{
+// 	name:                   "test-mcp-server",
+// 	needsApproval:          true,
+// 	approvalContactChannel: testContactChannel.name,
+// }
 
-var testMCPTool = &TestMCPTool{
-	name:        "test-mcp-server-test-tool",
-	mcpServer:   testMCPServer.name,
-	mcpToolName: "test-tool",
-}
+// var testMCPTool = &TestMCPTool{
+// 	name:        "test-mcp-server-test-tool",
+// 	mcpServer:   testMCPServer.name,
+// 	mcpToolName: "test-tool",
+// }
 
 var trtcForAddTool = &TestTaskRunToolCall{
 	name:      "test-taskruntoolcall",
@@ -240,10 +240,10 @@ func setupTestAddTool(ctx context.Context) func() {
 
 // TestMCPServer represents a test MCPServer resource
 type TestMCPServer struct {
-	name                   string
-	contactChannelName     string
-	needsApproval          bool
-	needsApprovalChecking  bool
+	name string
+	// contactChannelName     string
+	needsApproval bool
+	// needsApprovalChecking  bool
 	approvalContactChannel string
 	mcpServer              *kubechainv1alpha1.MCPServer
 }

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -2,10 +2,12 @@ package taskruntoolcall
 
 import (
 	"context"
+	"fmt"
 
 	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -17,10 +19,32 @@ var addTool = &TestTool{
 	toolType: "function",
 }
 
+var testContactChannel = &TestContactChannel{
+	name:        "test-contact-channel",
+	channelType: "slack",
+	secretName:  testSecret.name,
+}
+
+var testMCPServer = &TestMCPServer{
+	name:                   "test-mcp-server",
+	needsApproval:          true,
+	approvalContactChannel: testContactChannel.name,
+}
+
+var testMCPTool = &TestMCPTool{
+	name:        "test-mcp-server-test-tool",
+	mcpServer:   testMCPServer.name,
+	mcpToolName: "test-tool",
+}
+
 var trtcForAddTool = &TestTaskRunToolCall{
 	name:      "test-taskruntoolcall",
 	toolName:  addTool.name,
 	arguments: `{"a": 2, "b": 3}`,
+}
+
+var testSecret = &TestSecret{
+	name: "test-secret",
 }
 
 // TestTool represents a test Tool resource
@@ -28,6 +52,93 @@ type TestTool struct {
 	name     string
 	toolType string
 	tool     *kubechainv1alpha1.Tool
+}
+
+// TestSecret represents a test secret for storing API keys
+type TestSecret struct {
+	name   string
+	secret *corev1.Secret
+}
+
+// TestContactChannel represents a test ContactChannel resource
+type TestContactChannel struct {
+	name           string
+	channelType    string
+	secretName     string
+	contactChannel *kubechainv1alpha1.ContactChannel
+}
+
+func (t *TestContactChannel) Setup(ctx context.Context) *kubechainv1alpha1.ContactChannel {
+	By("creating the contact channel")
+	contactChannel := &kubechainv1alpha1.ContactChannel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.name,
+			Namespace: "default",
+		},
+		Spec: kubechainv1alpha1.ContactChannelSpec{
+			ChannelType: t.channelType,
+			APIKeyFrom: kubechainv1alpha1.APIKeySource{
+				SecretKeyRef: kubechainv1alpha1.SecretKeyRef{
+					Name: t.secretName,
+					Key:  "api-key",
+				},
+			},
+		},
+	}
+
+	// Add specific config based on channel type
+	if t.channelType == "slack" {
+		contactChannel.Spec.SlackConfig = &kubechainv1alpha1.SlackChannelConfig{
+			ChannelOrUserID: "C12345678",
+		}
+	} else if t.channelType == "email" {
+		contactChannel.Spec.EmailConfig = &kubechainv1alpha1.EmailChannelConfig{
+			Address: "test@example.com",
+		}
+	}
+
+	_ = k8sClient.Delete(ctx, contactChannel) // Delete if exists
+	err := k8sClient.Create(ctx, contactChannel)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.name, Namespace: "default"}, contactChannel)).To(Succeed())
+	t.contactChannel = contactChannel
+	return contactChannel
+}
+
+func (t *TestContactChannel) SetupWithStatus(ctx context.Context, status kubechainv1alpha1.ContactChannelStatus) *kubechainv1alpha1.ContactChannel {
+	contactChannel := t.Setup(ctx)
+	contactChannel.Status = status
+	Expect(k8sClient.Status().Update(ctx, contactChannel)).To(Succeed())
+	t.contactChannel = contactChannel
+	return contactChannel
+}
+
+func (t *TestContactChannel) Teardown(ctx context.Context) {
+	By("deleting the contact channel")
+	_ = k8sClient.Delete(ctx, t.contactChannel)
+}
+
+func (t *TestSecret) Setup(ctx context.Context) *corev1.Secret {
+	By("creating the secret")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.name,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"api-key": []byte("test-api-key"),
+		},
+	}
+	_ = k8sClient.Delete(ctx, secret) // Delete if exists
+	err := k8sClient.Create(ctx, secret)
+	Expect(err).NotTo(HaveOccurred())
+	t.secret = secret
+	return secret
+}
+
+func (t *TestSecret) Teardown(ctx context.Context) {
+	By("deleting the secret")
+	_ = k8sClient.Delete(ctx, t.secret)
 }
 
 // TestTaskRunToolCall represents a test TaskRunToolCall resource
@@ -71,9 +182,9 @@ func (t *TestTaskRunToolCall) Setup(ctx context.Context) *kubechainv1alpha1.Task
 	return taskRunToolCall
 }
 
-func (t *TestTool) Teardown(ctx context.Context) {
-	By("deleting the tool")
-	_ = k8sClient.Delete(ctx, t.tool)
+func (t *TestTaskRunToolCall) Teardown(ctx context.Context) {
+	By("deleting the taskruntoolcall")
+	_ = k8sClient.Delete(ctx, t.taskRunToolCall)
 }
 
 func (t *TestTool) SetupWithStatus(ctx context.Context, status kubechainv1alpha1.ToolStatus) *kubechainv1alpha1.Tool {
@@ -110,23 +221,12 @@ func (t *TestTool) Setup(ctx context.Context) *kubechainv1alpha1.Tool {
 	return tool
 }
 
-// reconciler creates a new reconciler for testing
-// Note, at the time of this writing there's not a lot going on in here
-// but future updates will add a MockMCPManager to do things specific to the TRTC flow
-func reconciler() (*TaskRunToolCallReconciler, *record.FakeRecorder) {
-	By("creating a test reconciler")
-	recorder := record.NewFakeRecorder(10)
-
-	reconciler := &TaskRunToolCallReconciler{
-		Client:   k8sClient,
-		Scheme:   k8sClient.Scheme(),
-		recorder: recorder,
-	}
-
-	return reconciler, recorder
+func (t *TestTool) Teardown(ctx context.Context) {
+	By("deleting the tool")
+	_ = k8sClient.Delete(ctx, t.tool)
 }
 
-// setupTestTools sets up all the tools needed for testing
+// setupTestAddTools sets up all the tools needed for testing
 func setupTestAddTool(ctx context.Context) func() {
 	addTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
 		Ready:  true,
@@ -136,4 +236,150 @@ func setupTestAddTool(ctx context.Context) func() {
 	return func() {
 		addTool.Teardown(ctx)
 	}
+}
+
+// TestMCPServer represents a test MCPServer resource
+type TestMCPServer struct {
+	name                   string
+	contactChannelName     string
+	needsApproval          bool
+	needsApprovalChecking  bool
+	approvalContactChannel string
+	mcpServer              *kubechainv1alpha1.MCPServer
+}
+
+func (t *TestMCPServer) Setup(ctx context.Context) *kubechainv1alpha1.MCPServer {
+	By("creating the MCP server")
+	mcpServer := &kubechainv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.name,
+			Namespace: "default",
+		},
+		Spec: kubechainv1alpha1.MCPServerSpec{
+			Transport: "stdio",
+		},
+	}
+
+	if t.needsApproval && t.approvalContactChannel != "" {
+		mcpServer.Spec.ApprovalContactChannel = &kubechainv1alpha1.LocalObjectReference{
+			Name: t.approvalContactChannel,
+		}
+	}
+
+	_ = k8sClient.Delete(ctx, mcpServer) // Delete if exists
+	err := k8sClient.Create(ctx, mcpServer)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.name, Namespace: "default"}, mcpServer)).To(Succeed())
+	t.mcpServer = mcpServer
+	return mcpServer
+}
+
+func (t *TestMCPServer) SetupWithStatus(ctx context.Context, status kubechainv1alpha1.MCPServerStatus) *kubechainv1alpha1.MCPServer {
+	mcpServer := t.Setup(ctx)
+	mcpServer.Status = status
+	Expect(k8sClient.Status().Update(ctx, mcpServer)).To(Succeed())
+	t.mcpServer = mcpServer
+	return mcpServer
+}
+
+func (t *TestMCPServer) Teardown(ctx context.Context) {
+	By("deleting the MCP server")
+	_ = k8sClient.Delete(ctx, t.mcpServer)
+}
+
+// MockMCPManager is a struct that mocks the essential MCPServerManager functionality for testing
+// MCPManagerInterface defines the minimum interface our mock needs to implement
+type MCPManagerInterface interface {
+	CallTool(ctx context.Context, serverName, toolName string, args map[string]interface{}) (string, error)
+}
+
+// MockMCPManager is a struct that mocks the essential MCPServerManager functionality for testing
+type MockMCPManager struct {
+	NeedsApproval bool // Flag to control if mock MCP tools need approval
+}
+
+// CallTool implements the MCPManager.CallTool method
+func (m *MockMCPManager) CallTool(ctx context.Context, serverName, toolName string, args map[string]interface{}) (string, error) {
+	// If we're testing the approval flow, return an error to prevent direct execution
+	if m.NeedsApproval {
+		return "", fmt.Errorf("tool requires approval")
+	}
+
+	// For non-approval tests, pretend to add the numbers
+	if a, ok := args["a"].(float64); ok {
+		if b, ok := args["b"].(float64); ok {
+			return fmt.Sprintf("%v", a+b), nil
+		}
+	}
+
+	return "5", nil // Default result
+}
+
+// TestMCPTool represents a test Tool resource for MCP
+type TestMCPTool struct {
+	name        string
+	mcpServer   string
+	mcpToolName string
+	tool        *kubechainv1alpha1.Tool
+}
+
+func (t *TestMCPTool) Setup(ctx context.Context) *kubechainv1alpha1.Tool {
+	By("creating the MCP tool")
+	toolName := t.mcpServer + "__" + t.mcpToolName
+	tool := &kubechainv1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.name,
+			Namespace: "default",
+		},
+		Spec: kubechainv1alpha1.ToolSpec{
+			ToolType:    "function",
+			Name:        toolName,
+			Description: "Test MCP tool",
+			Execute: kubechainv1alpha1.ToolExecute{
+				Builtin: &kubechainv1alpha1.BuiltinToolSpec{
+					Name: "add",
+				},
+			},
+		},
+	}
+	_ = k8sClient.Delete(ctx, tool) // Delete if exists
+	err := k8sClient.Create(ctx, tool)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: t.name, Namespace: "default"}, tool)).To(Succeed())
+	t.tool = tool
+	return tool
+}
+
+func (t *TestMCPTool) SetupWithStatus(ctx context.Context, status kubechainv1alpha1.ToolStatus) *kubechainv1alpha1.Tool {
+	tool := t.Setup(ctx)
+	tool.Status = status
+	Expect(k8sClient.Status().Update(ctx, tool)).To(Succeed())
+	t.tool = tool
+	return tool
+}
+
+func (t *TestMCPTool) Teardown(ctx context.Context) {
+	By("deleting the MCP tool")
+	_ = k8sClient.Delete(ctx, t.tool)
+}
+
+// reconciler creates a new reconciler for testing
+func reconciler() (*TaskRunToolCallReconciler, *record.FakeRecorder) {
+	By("creating a test reconciler")
+	recorder := record.NewFakeRecorder(10)
+
+	mockManager := &MockMCPManager{
+		NeedsApproval: false,
+	}
+
+	reconciler := &TaskRunToolCallReconciler{
+		Client:   k8sClient,
+		Scheme:   k8sClient.Scheme(),
+		recorder: recorder,
+	}
+
+	// Set the MCPManager field directly using type assertion
+	reconciler.MCPManager = interface{}(mockManager).(MCPManagerInterface)
+
+	return reconciler, recorder
 }

--- a/kubechain/internal/mcpmanager/mcpmanager.go
+++ b/kubechain/internal/mcpmanager/mcpmanager.go
@@ -25,6 +25,10 @@ type MCPServerManager struct {
 	client      ctrlclient.Client // Kubernetes client for accessing resources
 }
 
+type MCPManagerInterface interface {
+	CallTool(ctx context.Context, serverName, toolName string, args map[string]interface{}) (string, error)
+}
+
 // MCPConnection represents a connection to an MCP server
 type MCPConnection struct {
 	// ServerName is the name of the MCPServer resource


### PR DESCRIPTION
I'm 99 percent sure there is repetition going on `utils_test.go` between taskrun and taskruntoolcontroller, in both this and previous PRs. I want to circle back on those as we're starting to actually get to the good part.

This PR tests using an MCP Tool without approval and passing statuses accordingly. 