### PR TITLE
5 of X: Transition to AwaitingHumanApproval with real request to HL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 **/CLAUDE.local.md
+*__debug_bin*

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -4,6 +4,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type TaskRunToolCallStatusType string
+
+const (
+	TaskRunToolCallStatusTypeReady                        TaskRunToolCallStatusType = "Ready"
+	TaskRunToolCallStatusTypeError                        TaskRunToolCallStatusType = "Error"
+	TaskRunToolCallStatusTypePending                      TaskRunToolCallStatusType = "Pending"
+	TaskRunToolCallStatusTypeAwaitingHumanApproval        TaskRunToolCallStatusType = "AwaitingHumanApproval"
+	TaskRunToolCallStatusTypeAwaitingHumanInput           TaskRunToolCallStatusType = "AwaitingHumanInput"
+	TaskRunToolCallStatusTypeAwaitingSubAgent             TaskRunToolCallStatusType = "AwaitingSubAgent"
+	TaskRunToolCallStatusTypeErrorRequestingHumanApproval TaskRunToolCallStatusType = "ErrorRequestingHumanApproval"
+)
+
 // TaskRunToolCallSpec defines the desired state of TaskRunToolCall
 type TaskRunToolCallSpec struct {
 	// ToolCallId is the unique identifier for this tool call
@@ -33,8 +45,8 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;AwaitingHumanApproval;AwaitingHumanInput;AwaitingSubAgent
-	Status string `json:"status,omitempty"`
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;AwaitingHumanApproval;AwaitingHumanInput;AwaitingSubAgent;ErrorRequestingHumanApproval
+	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status
 	// +optional

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -140,6 +140,7 @@ spec:
                 - AwaitingHumanApproval
                 - AwaitingHumanInput
                 - AwaitingSubAgent
+                - ErrorRequestingHumanApproval
                 type: string
               statusDetail:
                 description: StatusDetail provides additional details about the current

--- a/kubechain/config/manager/kustomization.yaml
+++ b/kubechain/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/humanlayer/smallchain
-  newTag: v0.1.12
+  newName: controller
+  newTag: "202503261200"

--- a/kubechain/config/samples/kubechain_v1alpha_contactchannel_with_approval.yaml
+++ b/kubechain/config/samples/kubechain_v1alpha_contactchannel_with_approval.yaml
@@ -1,0 +1,57 @@
+# Remember to add your OpenAI and HumanLayer secrets
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: ContactChannel
+metadata:
+  name: make-fetch-happen-channel
+spec:
+  channelType: slack
+  apiKeyFrom:
+    secretKeyRef:
+      name: humanlayer-api-key
+      key: api-key
+  slackConfig:
+    channelOrUserID: "C07HR5JL15F"  # Replace with actual Slack channel ID
+    contextAboutChannelOrUser: "Channel for approving web fetch operations"
+---
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: LLM
+metadata:
+  name: gpt-4o
+spec:
+  provider: openai
+  apiKeyFrom:
+    secretKeyRef:
+      name: openai
+      key: OPENAI_API_KEY
+---
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: make-fetch-happen-server
+spec:
+  transport: "stdio"
+  command: "uvx"
+  args: ["mcp-server-fetch"]
+  approvalContactChannel:
+    name: make-fetch-happen-channel
+---
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: Agent
+metadata:
+  name: make-fetch-happen-agent
+spec:
+  llmRef:
+    name: gpt-4o
+  system: |
+    You are a helpful assistant. Your job is to help the user with their tasks.
+  mcpServers:
+    - name: make-fetch-happen-server
+---
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: Task
+metadata:
+  name: make-fetch-happen-task
+spec:
+  agentRef:
+    name: make-fetch-happen-agent
+  message: "What is on the front page of planetscale.com?"

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -688,7 +688,8 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				logger.Error(err, "Failed to update TaskRunToolCall status")
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
+
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 	}
 

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -43,6 +43,7 @@ type TaskRunToolCallReconciler struct {
 	recorder   record.EventRecorder
 	server     *http.Server
 	MCPManager mcpmanager.MCPManagerInterface
+	HLClient   humanlayer.HumanLayerClientInterface
 }
 
 func (r *TaskRunToolCallReconciler) webhookHandler(w http.ResponseWriter, req *http.Request) {
@@ -643,6 +644,90 @@ func (r *TaskRunToolCallReconciler) getMCPServer(ctx context.Context, trtc *kube
 	return &mcpServer, mcpServer.Spec.ApprovalContactChannel != nil, nil
 }
 
+// getContactChannel fetches and validates the ContactChannel resource
+func (r *TaskRunToolCallReconciler) getContactChannel(ctx context.Context, mcpServer *kubechainv1alpha1.MCPServer, trtcNamespace string) (*kubechainv1alpha1.ContactChannel, error) {
+	var contactChannel kubechainv1alpha1.ContactChannel
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: trtcNamespace,
+		Name:      mcpServer.Spec.ApprovalContactChannel.Name,
+	}, &contactChannel); err != nil {
+
+		err := fmt.Errorf("failed to get ContactChannel: %v", err)
+		return nil, err
+	}
+
+	// Validate that the ContactChannel is ready
+	if !contactChannel.Status.Ready {
+		err := fmt.Errorf("ContactChannel %s is not ready: %s", contactChannel.Name, contactChannel.Status.StatusDetail)
+		return nil, err
+	}
+
+	return &contactChannel, nil
+}
+
+func (r *TaskRunToolCallReconciler) getHumanLayerAPIKey(ctx context.Context, secretKeyRefName string, secretKeyRefKey string, trtcNamespace string) (string, error) {
+	var secret corev1.Secret
+	err := r.Get(ctx, client.ObjectKey{
+		Namespace: trtcNamespace,
+		Name:      secretKeyRefName,
+	}, &secret)
+	if err != nil {
+		err := fmt.Errorf("failed to get API key secret: %v", err)
+		return "", err
+	}
+
+	apiKey := string(secret.Data[secretKeyRefKey])
+	return apiKey, nil
+}
+
+func (r *TaskRunToolCallReconciler) setStatusError(ctx context.Context, trtcStatus kubechainv1alpha1.TaskRunToolCallStatusType, eventType string, trtc *kubechainv1alpha1.TaskRunToolCall, err error) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	trtc.Status.Status = trtcStatus
+
+	// Handle nil error case
+	errorMessage := "Unknown error occurred"
+	if err != nil {
+		errorMessage = err.Error()
+	}
+
+	trtc.Status.StatusDetail = errorMessage
+	trtc.Status.Error = errorMessage
+	r.recorder.Event(trtc, corev1.EventTypeWarning, eventType, errorMessage)
+
+	if err := r.Status().Update(ctx, trtc); err != nil {
+		logger.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *TaskRunToolCallReconciler) postToHumanLayer(ctx context.Context, trtc *kubechainv1alpha1.TaskRunToolCall, contactChannel *kubechainv1alpha1.ContactChannel, apiKey string) (int, error) {
+	client := r.HLClient.NewHumanLayerClient()
+
+	switch contactChannel.Spec.ChannelType {
+	case "slack":
+		client.SetSlackConfig(contactChannel.Spec.SlackConfig)
+	case "email":
+		client.SetEmailConfig(contactChannel.Spec.EmailConfig)
+	default:
+		return 0, fmt.Errorf("unsupported channel type: %s", contactChannel.Spec.ChannelType)
+	}
+
+	client.SetFunctionCallSpec("approve_tool_call", map[string]interface{}{
+		"tool_name": trtc.Spec.ToolRef.Name,
+		"task_run":  trtc.Spec.TaskRunRef.Name,
+		"namespace": trtc.Namespace,
+	})
+
+	client.SetCallID("call-" + uuid.New().String())
+	client.SetRunID(trtc.Name)
+	client.SetAPIKey(apiKey)
+
+	_, statusCode, err := client.RequestApproval(ctx)
+
+	return statusCode, err
+}
+
 // Reconcile processes TaskRunToolCall objects.
 func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -658,6 +743,11 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, nil
+	}
+
+	// Do not pass GO, do not collect $200, if we've errored
+	if trtc.Status.Status == "ErrorRequestingHumanApproval" {
 		return ctrl.Result{}, nil
 	}
 
@@ -678,7 +768,20 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
+		// No approval yet? Get back in the loop.
+		if needsApproval && trtc.Status.Status == "AwaitingHumanApproval" {
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
 		if needsApproval {
+
+			trtcNamespace := trtc.Namespace
+			contactChannel, err := r.getContactChannel(ctx, mcpServer, trtcNamespace)
+
+			if err != nil {
+				return r.setStatusError(ctx, kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval, "NoContactChannel", &trtc, err)
+			}
+
 			trtc.Status.Status = "AwaitingHumanApproval"
 			trtc.Status.StatusDetail = fmt.Sprintf("Waiting for human approval via contact channel %s", mcpServer.Spec.ApprovalContactChannel.Name)
 			r.recorder.Event(&trtc, corev1.EventTypeNormal, "AwaitingHumanApproval",
@@ -687,6 +790,27 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			if err := r.Status().Update(ctx, &trtc); err != nil {
 				logger.Error(err, "Failed to update TaskRunToolCall status")
 				return ctrl.Result{}, err
+			}
+
+			apiKey, err := r.getHumanLayerAPIKey(ctx, contactChannel.Spec.APIKeyFrom.SecretKeyRef.Name, contactChannel.Spec.APIKeyFrom.SecretKeyRef.Key, trtcNamespace)
+
+			if err != nil || apiKey == "" {
+				return r.setStatusError(ctx, kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval, "NoAPIKey", &trtc, err)
+			}
+
+			if r.HLClient == nil {
+				err := fmt.Errorf("HLClient not initialized")
+				return r.setStatusError(ctx, kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval, "NoHumanLayerClient", &trtc, err)
+			}
+
+			statusCode, err := r.postToHumanLayer(ctx, &trtc, contactChannel, apiKey)
+
+			if statusCode != 200 {
+				errorMsg := fmt.Errorf("HumanLayer request failed with status code: %d", statusCode)
+				if err != nil {
+					errorMsg = fmt.Errorf("HumanLayer request failed with status code %d: %v", statusCode, err)
+				}
+				return r.setStatusError(ctx, kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval, "HumanLayerRequestFailed", &trtc, errorMsg)
 			}
 
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -731,6 +855,16 @@ func (r *TaskRunToolCallReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Initialize MCPManager if it hasn't been initialized yet
 	if r.MCPManager == nil {
 		r.MCPManager = mcpmanager.NewMCPServerManager()
+	}
+
+	if r.HLClient == nil {
+		client, err := humanlayer.NewHumanLayerClient("")
+
+		if err != nil {
+			return err
+		}
+
+		r.HLClient = client
 	}
 
 	go func() {

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -680,6 +680,7 @@ func (r *TaskRunToolCallReconciler) getHumanLayerAPIKey(ctx context.Context, sec
 	return apiKey, nil
 }
 
+//nolint:unparam
 func (r *TaskRunToolCallReconciler) setStatusError(ctx context.Context, trtcStatus kubechainv1alpha1.TaskRunToolCallStatusType, eventType string, trtc *kubechainv1alpha1.TaskRunToolCall, err error) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	trtc.Status.Status = trtcStatus
@@ -747,7 +748,7 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Do not pass GO, do not collect $200, if we've errored
-	if trtc.Status.Status == "ErrorRequestingHumanApproval" {
+	if trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval {
 		return ctrl.Result{}, nil
 	}
 
@@ -769,7 +770,7 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		// No approval yet? Get back in the loop.
-		if needsApproval && trtc.Status.Status == "AwaitingHumanApproval" {
+		if needsApproval && trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeAwaitingHumanApproval {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
@@ -777,7 +778,6 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 			trtcNamespace := trtc.Namespace
 			contactChannel, err := r.getContactChannel(ctx, mcpServer, trtcNamespace)
-
 			if err != nil {
 				return r.setStatusError(ctx, kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval, "NoContactChannel", &trtc, err)
 			}
@@ -859,7 +859,6 @@ func (r *TaskRunToolCallReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if r.HLClient == nil {
 		client, err := humanlayer.NewHumanLayerClient("")
-
 		if err != nil {
 			return err
 		}

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -2,9 +2,11 @@ package taskruntoolcall
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+	"github.com/humanlayer/smallchain/kubechain/internal/humanlayer"
 	"github.com/humanlayer/smallchain/kubechain/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -223,51 +225,22 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 	// Tests for approval workflow
 	Context("Pending -> AwaitingHumanApproval (MCP Tool)", func() {
 		It("transitions to AwaitingHumanApproval when MCPServer has approval channel", func() {
-			// Setup MCP server without approval channel
-			testSecret.Setup(ctx)
-			mcpServer := &TestMCPServer{
-				name:                   "test-mcp-with-approval",
-				needsApproval:          true,
-				approvalContactChannel: "slack",
-			}
-			mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
-				Connected: true,
-				Status:    "Ready",
-			})
-			defer mcpServer.Teardown(ctx)
 
-			// Setup MCP tool
-			mcpTool := &TestMCPTool{
-				name:        "test-mcp-with-approval-tool",
-				mcpServer:   mcpServer.name,
-				mcpToolName: "test-tool",
-			}
-
-			tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
-				Ready:  true,
-				Status: "Ready",
-			})
-			defer mcpTool.Teardown(ctx)
-
-			// Create TaskRunToolCall with MCP tool reference
-			taskRunToolCall := &TestTaskRunToolCall{
-				name:      "test-mcp-with-approval-trtc",
-				toolName:  tool.Spec.Name,
-				arguments: `{"a": 2, "b": 3}`,
-			}
-			trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
-				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
-				Status:       "Pending",
-				StatusDetail: "Ready for execution",
-				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-			})
-			defer taskRunToolCall.Teardown(ctx)
+			// Note setupTestApprovalResources sets up the MCP server, MCP tool, and TaskRunToolCall
+			trtc, teardown := setupTestApprovalResources(ctx)
+			defer teardown()
 
 			By("reconciling the taskruntoolcall that uses MCP tool with approval")
 			reconciler, recorder := reconciler()
 
 			reconciler.MCPManager = &MockMCPManager{
 				NeedsApproval: true,
+			}
+
+			reconciler.HLClient = &humanlayer.MockHumanLayerClient{
+				ShouldFail:  false,
+				StatusCode:  200,
+				ReturnError: nil,
 			}
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -292,362 +265,57 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeAwaitingHumanApproval))
 			Expect(updatedTRTC.Status.StatusDetail).To(ContainSubstring("Waiting for human approval via contact channel"))
 
+			_ = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trtc.Name,
+				Namespace: trtc.Namespace,
+			}, updatedTRTC)
+
 			By("checking that appropriate events were emitted")
 			utils.ExpectRecorder(recorder).ToEmitEventContaining("AwaitingHumanApproval")
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeAwaitingHumanApproval))
 		})
 	})
 
-	/*
-		Context("ErrorRequestingHumanApproval -> ErrorRequestingHumanApproval", func() {
-			It("stays in ErrorRequestingHumanApproval if the error is not retryable", func() {
-				// Setup MCP server without approval channel
-				testSecret.Setup(ctx)
-				mcpServer := &TestMCPServer{
-					name:                   "test-mcp-with-approval",
-					needsApproval:          true,
-					approvalContactChannel: "",
-				}
-				mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
-					Connected: true,
-					Status:    "Ready",
-				})
-				defer mcpServer.Teardown(ctx)
+	Context("Pending -> ErrorRequestingHumanApproval (MCP Tool)", func() {
+		It("transitions to ErrorRequestingHumanApproval when request to HumanLayer fails", func() {
 
-				// Setup MCP tool
-				mcpTool := &TestMCPTool{
-					name:        "test-mcp-with-approval-tool",
-					mcpServer:   mcpServer.name,
-					mcpToolName: "test-tool",
-				}
+			// Note setupTestApprovalResources sets up the MCP server, MCP tool, and TaskRunToolCall
+			trtc, teardown := setupTestApprovalResources(ctx)
+			defer teardown()
 
-				tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
-					Ready:  true,
-					Status: "Ready",
-				})
-				defer mcpTool.Teardown(ctx)
+			By("reconciling the taskruntoolcall that uses MCP tool with approval")
+			reconciler, _ := reconciler()
 
-				// Create TaskRunToolCall with MCP tool reference
-				taskRunToolCall := &TestTaskRunToolCall{
-					name:      "test-mcp-with-approval-trtc",
-					toolName:  tool.Spec.Name,
-					arguments: `{"a": 2, "b": 3}`,
-				}
-				trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
-					Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
-					Status:       kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval,
-					StatusDetail: "Ready for execution",
-					StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-				})
-				defer taskRunToolCall.Teardown(ctx)
+			reconciler.MCPManager = &MockMCPManager{
+				NeedsApproval: true,
+			}
 
-				By("reconciling the taskruntoolcall that uses MCP tool with approval")
-				reconciler, _ := reconciler()
+			reconciler.HLClient = &humanlayer.MockHumanLayerClient{
+				ShouldFail:  true,
+				StatusCode:  500,
+				ReturnError: fmt.Errorf("While taking pizzas from the kitchen to the lobby, Pete passed through the server room where he tripped over a network cable and now there's pizza all over the place. Also this request failed. No more pizza in the server room Pete."),
+			}
 
-				reconciler.MCPManager = &MockMCPManager{NeedsApproval: true}
-
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      trtc.Name,
-						Namespace: trtc.Namespace,
-					},
-				})
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Requeue).To(BeFalse()) // No requeue since initialization is complete\
-				Expect(trtc.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval))
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      trtc.Name,
+					Namespace: trtc.Namespace,
+				},
 			})
-		})
-	*/
-})
 
-/*
-var _ = Describe("TaskRunToolCall Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-taskruntoolcall"
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default",
-		}
-
-		BeforeEach(func() {
-			// Create test Tool for direct execution
-			tool := &kubechainv1alpha1.Tool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "add",
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.ToolSpec{
-					ToolType:    "function",
-					Name:        "add",
-					Description: "Add two numbers",
-					Execute: kubechainv1alpha1.ToolExecute{
-						Builtin: &kubechainv1alpha1.BuiltinToolSpec{
-							Name: "add",
-						},
-					},
-				},
-			}
-			_ = k8sClient.Delete(ctx, tool)
-			time.Sleep(100 * time.Millisecond)
-			Expect(k8sClient.Create(ctx, tool)).To(Succeed())
-
-			// Mark Tool as ready
-			tool.Status.Ready = true
-			tool.Status.Status = "Ready"
-			Expect(k8sClient.Status().Update(ctx, tool)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			// Cleanup test resources
-			By("Cleanup the test Tool")
-			tool := &kubechainv1alpha1.Tool{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: "add", Namespace: "default"}, tool)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, tool)).To(Succeed())
-			}
-
-			By("Cleanup the test TaskRunToolCall")
-			trtc := &kubechainv1alpha1.TaskRunToolCall{}
-			err = k8sClient.Get(ctx, typeNamespacedName, trtc)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, trtc)).To(Succeed())
-			}
-		})
-
-		It("should successfully execute a function tool call", func() {
-			By("creating the taskruntoolcall")
-			trtc := &kubechainv1alpha1.TaskRunToolCall{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.TaskRunToolCallSpec{
-					TaskRunRef: kubechainv1alpha1.LocalObjectReference{
-						Name: "parent-taskrun",
-					},
-					ToolRef: kubechainv1alpha1.LocalObjectReference{
-						Name: "add",
-					},
-					Arguments: `{"a": 2, "b": 3}`,
-				},
-			}
-			Expect(k8sClient.Create(ctx, trtc)).To(Succeed())
-
-			By("reconciling the taskruntoolcall")
-			eventRecorder := record.NewFakeRecorder(10)
-			reconciler := &TaskRunToolCallReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				recorder: eventRecorder,
-			}
-
-			// First reconciliation - should initialize status
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
 
-			// Second reconciliation - should execute function
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("checking the taskruntoolcall status")
+			By("checking the taskruntoolcall status is set to ErrorRequestingHumanApproval")
 			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
-			err = k8sClient.Get(ctx, typeNamespacedName, updatedTRTC)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
-			Expect(updatedTRTC.Status.Result).To(Equal("5"))
-			Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
-			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Tool executed successfully"))
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trtc.Name,
+				Namespace: trtc.Namespace,
+			}, updatedTRTC)
 
-			By("checking that execution events were emitted")
-			utils.ExpectRecorder(eventRecorder).ToEmitEventContaining("ExecutionSucceeded")
-		})
-
-		It("should fail with invalid arguments", func() {
-			By("creating the taskruntoolcall with invalid JSON")
-			trtc := &kubechainv1alpha1.TaskRunToolCall{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.TaskRunToolCallSpec{
-					TaskRunRef: kubechainv1alpha1.LocalObjectReference{
-						Name: "parent-taskrun",
-					},
-					ToolRef: kubechainv1alpha1.LocalObjectReference{
-						Name: "add",
-					},
-					Arguments: `invalid json`,
-				},
-			}
-			Expect(k8sClient.Create(ctx, trtc)).To(Succeed())
-
-			By("reconciling the taskruntoolcall")
-			eventRecorder := record.NewFakeRecorder(10)
-			reconciler := &TaskRunToolCallReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				recorder: eventRecorder,
-			}
-
-			// First reconciliation - should initialize status
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Second reconciliation - should fail validation
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).To(HaveOccurred())
-
-			By("checking the taskruntoolcall status")
-			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
-			err = k8sClient.Get(ctx, typeNamespacedName, updatedTRTC)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedTRTC.Status.Status).To(Equal("Error"))
-			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Invalid arguments JSON"))
-
-			By("checking that a validation failed event was created")
-			utils.ExpectRecorder(eventRecorder).ToEmitEventContaining("ExecutionFailed")
-		})
-
-		It("should transition to AwaitingHumanApproval when MCP tool's server has approval contact channel", func() {
-			By("creating a contact channel")
-
-			// Create a mock secret first
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					"api-key": []byte("test-key"),
-				},
-			}
-			_ = k8sClient.Delete(ctx, secret) // Delete if exists
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
-
-			contactChannel := &kubechainv1alpha1.ContactChannel{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-contact-channel",
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.ContactChannelSpec{
-					ChannelType: "slack",
-					APIKeyFrom: kubechainv1alpha1.APIKeySource{
-						SecretKeyRef: kubechainv1alpha1.SecretKeyRef{
-							Name: "test-secret",
-							Key:  "api-key",
-						},
-					},
-					SlackConfig: &kubechainv1alpha1.SlackChannelConfig{
-						ChannelOrUserID: "C12345678",
-					},
-				},
-				Status: kubechainv1alpha1.ContactChannelStatus{
-					Ready:  true,
-					Status: "Ready",
-				},
-			}
-			Expect(k8sClient.Create(ctx, contactChannel)).To(Succeed())
-
-			By("creating an MCPServer with approval contact channel")
-			mcpServer := &kubechainv1alpha1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-mcp-server",
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.MCPServerSpec{
-					Transport: "stdio",
-					ApprovalContactChannel: &kubechainv1alpha1.LocalObjectReference{
-						Name: "test-contact-channel",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
-
-			By("creating an MCP tool")
-			tool := &kubechainv1alpha1.Tool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-mcp-server-test-tool",
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.ToolSpec{
-					ToolType:    "function",
-					Name:        "test-mcp-server__test-tool",
-					Description: "A tool that requires human approval",
-					Execute: kubechainv1alpha1.ToolExecute{
-						Builtin: &kubechainv1alpha1.BuiltinToolSpec{
-							Name: "add",
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, tool)).To(Succeed())
-
-			By("creating the taskruntoolcall")
-			trtc := &kubechainv1alpha1.TaskRunToolCall{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
-					Namespace: "default",
-				},
-				Spec: kubechainv1alpha1.TaskRunToolCallSpec{
-					TaskRunRef: kubechainv1alpha1.LocalObjectReference{
-						Name: "parent-taskrun",
-					},
-					ToolRef: kubechainv1alpha1.LocalObjectReference{
-						Name: "test-mcp-server__test-tool",
-					},
-					Arguments: `{"a": 2, "b": 3}`,
-				},
-			}
-			Expect(k8sClient.Create(ctx, trtc)).To(Succeed())
-
-			By("reconciling the taskruntoolcall")
-			eventRecorder := record.NewFakeRecorder(10)
-			reconciler := &TaskRunToolCallReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				recorder: eventRecorder,
-			}
-
-			// First reconciliation (but not the contrition variety) - should initialize status
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Second reconciliation - should transition to AwaitingHumanApproval
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("checking the taskruntoolcall status")
-			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
-			err = k8sClient.Get(ctx, typeNamespacedName, updatedTRTC)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhasePending))
-			Expect(updatedTRTC.Status.Status).To(Equal("AwaitingHumanApproval"))
-			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Waiting for human approval via contact channel test-contact-channel"))
-
-			By("checking that appropriate events were emitted")
-			utils.ExpectRecorder(eventRecorder).ToEmitEventContaining("AwaitingHumanApproval")
-
-			By("Cleanup")
-			Expect(k8sClient.Delete(ctx, contactChannel)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, tool)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval))
 		})
 	})
 })
-*/

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -143,79 +143,80 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionFailed")
 		})
 
-		// Tests for MCP tools without approval requirement
-		Context("Pending -> Succeeded (MCP Tool)", func() {
-			It("successfully executes an MCP tool without requiring approval", func() {
-				// Setup MCP server without approval channel
-				testSecret.Setup(ctx)
-				mcpServer := &TestMCPServer{
-					name:                   "test-mcp-no-approval",
-					needsApproval:          false,
-					approvalContactChannel: "",
-				}
-				mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
-					Connected: true,
-					Status:    "Ready",
-				})
-				defer mcpServer.Teardown(ctx)
+	})
 
-				// Setup MCP tool
-				mcpTool := &TestMCPTool{
-					name:        "test-mcp-no-approval-tool",
-					mcpServer:   mcpServer.name,
-					mcpToolName: "test-tool",
-				}
-				tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
-					Ready:  true,
-					Status: "Ready",
-				})
-				defer mcpTool.Teardown(ctx)
+	// Tests for MCP tools without approval requirement
+	Context("Pending -> Succeeded (MCP Tool)", func() {
+		It("successfully executes an MCP tool without requiring approval", func() {
+			// Setup MCP server without approval channel
+			testSecret.Setup(ctx)
+			mcpServer := &TestMCPServer{
+				name:                   "test-mcp-no-approval",
+				needsApproval:          false,
+				approvalContactChannel: "",
+			}
+			mcpServer.SetupWithStatus(ctx, kubechainv1alpha1.MCPServerStatus{
+				Connected: true,
+				Status:    "Ready",
+			})
+			defer mcpServer.Teardown(ctx)
 
-				// Create TaskRunToolCall with MCP tool reference
-				taskRunToolCall := &TestTaskRunToolCall{
-					name:      "test-mcp-no-approval-trtc",
-					toolName:  tool.Spec.Name,
-					arguments: `{"a": 2, "b": 3}`,
-				}
-				trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
-					Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
-					Status:       "Pending",
-					StatusDetail: "Ready for execution",
-					StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-				})
-				defer taskRunToolCall.Teardown(ctx)
+			// Setup MCP tool
+			mcpTool := &TestMCPTool{
+				name:        "test-mcp-no-approval-tool",
+				mcpServer:   mcpServer.name,
+				mcpToolName: "test-tool",
+			}
+			tool := mcpTool.SetupWithStatus(ctx, kubechainv1alpha1.ToolStatus{
+				Ready:  true,
+				Status: "Ready",
+			})
+			defer mcpTool.Teardown(ctx)
 
-				By("reconciling the taskruntoolcall that uses MCP tool without approval")
-				reconciler, recorder := reconciler()
+			// Create TaskRunToolCall with MCP tool reference
+			taskRunToolCall := &TestTaskRunToolCall{
+				name:      "test-mcp-no-approval-trtc",
+				toolName:  tool.Spec.Name,
+				arguments: `{"a": 2, "b": 3}`,
+			}
+			trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
+				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
+				Status:       "Pending",
+				StatusDetail: "Ready for execution",
+				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+			})
+			defer taskRunToolCall.Teardown(ctx)
 
-				reconciler.MCPManager = &MockMCPManager{
-					NeedsApproval: false, // This test specifically doesn't want approval
-				}
+			By("reconciling the taskruntoolcall that uses MCP tool without approval")
+			reconciler, recorder := reconciler()
 
-				_, err := reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      trtc.Name,
-						Namespace: trtc.Namespace,
-					},
-				})
+			reconciler.MCPManager = &MockMCPManager{
+				NeedsApproval: false, // This test specifically doesn't want approval
+			}
 
-				Expect(err).NotTo(HaveOccurred())
-
-				By("checking the taskruntoolcall status is set to Succeeded")
-				updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
-				err = k8sClient.Get(ctx, types.NamespacedName{
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
 					Name:      trtc.Name,
 					Namespace: trtc.Namespace,
-				}, updatedTRTC)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
-				Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
-				Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
-
-				By("checking that appropriate events were emitted")
-				utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
+				},
 			})
+
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the taskruntoolcall status is set to Succeeded")
+			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trtc.Name,
+				Namespace: trtc.Namespace,
+			}, updatedTRTC)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
+			Expect(updatedTRTC.Status.Status).To(Equal("Ready"))
+			Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
+
+			By("checking that appropriate events were emitted")
+			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionSucceeded")
 		})
 	})
 })

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -107,7 +107,6 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 				toolName:  addTool.name,
 				arguments: `invalid json`, // Invalid JSON
 			}
-			defer taskRunToolCall.Teardown(ctx)
 
 			trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
 				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
@@ -115,6 +114,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 				StatusDetail: "Ready for execution",
 				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
 			})
+
+			defer taskRunToolCall.Teardown(ctx)
 
 			By("reconciling the taskruntoolcall with invalid arguments")
 			reconciler, recorder := reconciler()
@@ -144,7 +145,6 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			By("checking that error events were emitted")
 			utils.ExpectRecorder(recorder).ToEmitEventContaining("ExecutionFailed")
 		})
-
 	})
 
 	// Tests for MCP tools without approval requirement
@@ -225,7 +225,6 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 	// Tests for approval workflow
 	Context("Pending -> AwaitingHumanApproval (MCP Tool)", func() {
 		It("transitions to AwaitingHumanApproval when MCPServer has approval channel", func() {
-
 			// Note setupTestApprovalResources sets up the MCP server, MCP tool, and TaskRunToolCall
 			trtc, teardown := setupTestApprovalResources(ctx)
 			defer teardown()
@@ -278,7 +277,6 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 
 	Context("Pending -> ErrorRequestingHumanApproval (MCP Tool)", func() {
 		It("transitions to ErrorRequestingHumanApproval when request to HumanLayer fails", func() {
-
 			// Note setupTestApprovalResources sets up the MCP server, MCP tool, and TaskRunToolCall
 			trtc, teardown := setupTestApprovalResources(ctx)
 			defer teardown()

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -288,12 +288,6 @@ func (t *TestMCPServer) Teardown(ctx context.Context) {
 }
 
 // MockMCPManager is a struct that mocks the essential MCPServerManager functionality for testing
-// MCPManagerInterface defines the minimum interface our mock needs to implement
-type MCPManagerInterface interface {
-	CallTool(ctx context.Context, serverName, toolName string, args map[string]interface{}) (string, error)
-}
-
-// MockMCPManager is a struct that mocks the essential MCPServerManager functionality for testing
 type MockMCPManager struct {
 	NeedsApproval bool // Flag to control if mock MCP tools need approval
 }
@@ -368,10 +362,6 @@ func reconciler() (*TaskRunToolCallReconciler, *record.FakeRecorder) {
 	By("creating a test reconciler")
 	recorder := record.NewFakeRecorder(10)
 
-	mockManager := &MockMCPManager{
-		NeedsApproval: false,
-	}
-
 	reconciler := &TaskRunToolCallReconciler{
 		Client:   k8sClient,
 		Scheme:   k8sClient.Scheme(),
@@ -379,7 +369,9 @@ func reconciler() (*TaskRunToolCallReconciler, *record.FakeRecorder) {
 	}
 
 	// Set the MCPManager field directly using type assertion
-	reconciler.MCPManager = interface{}(mockManager).(MCPManagerInterface)
+	reconciler.MCPManager = &MockMCPManager{
+		NeedsApproval: false,
+	}
 
 	return reconciler, recorder
 }

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -19,23 +19,23 @@ var addTool = &TestTool{
 	toolType: "function",
 }
 
-var testContactChannel = &TestContactChannel{
-	name:        "test-contact-channel",
-	channelType: "slack",
-	secretName:  testSecret.name,
-}
+// var testContactChannel = &TestContactChannel{
+// 	name:        "test-contact-channel",
+// 	channelType: "slack",
+// 	secretName:  testSecret.name,
+// }
 
-var testMCPServer = &TestMCPServer{
-	name:                   "test-mcp-server",
-	needsApproval:          true,
-	approvalContactChannel: testContactChannel.name,
-}
+// var testMCPServer = &TestMCPServer{
+// 	name:                   "test-mcp-server",
+// 	needsApproval:          true,
+// 	approvalContactChannel: testContactChannel.name,
+// }
 
-var testMCPTool = &TestMCPTool{
-	name:        "test-mcp-server-test-tool",
-	mcpServer:   testMCPServer.name,
-	mcpToolName: "test-tool",
-}
+// var testMCPTool = &TestMCPTool{
+// 	name:        "test-mcp-server-test-tool",
+// 	mcpServer:   testMCPServer.name,
+// 	mcpToolName: "test-tool",
+// }
 
 var trtcForAddTool = &TestTaskRunToolCall{
 	name:      "test-taskruntoolcall",
@@ -240,10 +240,10 @@ func setupTestAddTool(ctx context.Context) func() {
 
 // TestMCPServer represents a test MCPServer resource
 type TestMCPServer struct {
-	name                   string
-	contactChannelName     string
-	needsApproval          bool
-	needsApprovalChecking  bool
+	name string
+	// contactChannelName     string
+	needsApproval bool
+	// needsApprovalChecking  bool
 	approvalContactChannel string
 	mcpServer              *kubechainv1alpha1.MCPServer
 }

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -242,9 +242,7 @@ func setupTestAddTool(ctx context.Context) func() {
 // TestMCPServer represents a test MCPServer resource
 type TestMCPServer struct {
 	name                   string
-	contactChannelName     string
 	needsApproval          bool
-	needsApprovalChecking  bool
 	approvalContactChannel string
 	mcpServer              *kubechainv1alpha1.MCPServer
 }

--- a/kubechain/internal/humanlayer/hlclient.go
+++ b/kubechain/internal/humanlayer/hlclient.go
@@ -3,17 +3,19 @@
 package humanlayer
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
 
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	humanlayerapi "github.com/humanlayer/smallchain/kubechain/internal/humanlayerapi"
 )
 
 // NewHumanLayerClient creates a new API client using either the provided API key
 // or falling back to the HUMANLAYER_API_KEY environment variable. Similarly,
 // it uses the provided API base URL or falls back to HUMANLAYER_API_BASE.
-func NewHumanLayerClient(optionalApiBase string) (*humanlayerapi.APIClient, error) {
+func NewHumanLayerClient(optionalApiBase string) (HumanLayerClientInterface, error) {
 	config := humanlayerapi.NewConfiguration()
 
 	// Get API base from parameter or environment variable
@@ -43,5 +45,100 @@ func NewHumanLayerClient(optionalApiBase string) (*humanlayerapi.APIClient, erro
 	// Create the API client with the configuration
 	client := humanlayerapi.NewAPIClient(config)
 
-	return client, nil
+	return &HumanLayerClient{client: client}, nil
+}
+
+type HumanLayerClientWrapperInterface interface {
+	SetSlackConfig(slackConfig *kubechainv1alpha1.SlackChannelConfig)
+	SetEmailConfig(emailConfig *kubechainv1alpha1.EmailChannelConfig)
+	SetFunctionCallSpec(functionName string, args map[string]interface{})
+	SetCallID(callID string)
+	SetRunID(runID string)
+	SetAPIKey(apiKey string)
+	RequestApproval(ctx context.Context) (functionCall *humanlayerapi.FunctionCallOutput, statusCode int, err error)
+}
+
+type HumanLayerClientInterface interface {
+	NewHumanLayerClient() HumanLayerClientWrapperInterface
+}
+
+type HumanLayerClientWrapper struct {
+	client                *humanlayerapi.APIClient
+	slackChannelInput     *humanlayerapi.SlackContactChannelInput
+	emailContactChannel   *humanlayerapi.EmailContactChannel
+	functionCallSpecInput *humanlayerapi.FunctionCallSpecInput
+	callID                string
+	runID                 string
+	apiKey                string
+}
+
+type HumanLayerClient struct {
+	client *humanlayerapi.APIClient
+}
+
+func (h *HumanLayerClient) NewHumanLayerClient() HumanLayerClientWrapperInterface {
+	return &HumanLayerClientWrapper{
+		client: h.client,
+	}
+}
+
+func (h *HumanLayerClientWrapper) SetSlackConfig(slackConfig *kubechainv1alpha1.SlackChannelConfig) {
+	slackChannelInput := humanlayerapi.NewSlackContactChannelInput(slackConfig.ChannelOrUserID)
+
+	if slackConfig.ContextAboutChannelOrUser != "" {
+		slackChannelInput.SetContextAboutChannelOrUser(slackConfig.ContextAboutChannelOrUser)
+	}
+
+	h.slackChannelInput = slackChannelInput
+}
+
+func (h *HumanLayerClientWrapper) SetEmailConfig(emailConfig *kubechainv1alpha1.EmailChannelConfig) {
+	emailContactChannel := humanlayerapi.NewEmailContactChannel(emailConfig.Address)
+
+	if emailConfig.ContextAboutUser != "" {
+		emailContactChannel.SetContextAboutUser(emailConfig.ContextAboutUser)
+	}
+
+	h.emailContactChannel = emailContactChannel
+}
+
+func (h *HumanLayerClientWrapper) SetFunctionCallSpec(functionName string, args map[string]interface{}) {
+	// Create the function call input with required parameters
+	functionCallSpecInput := humanlayerapi.NewFunctionCallSpecInput(functionName, args)
+
+	h.functionCallSpecInput = functionCallSpecInput
+}
+
+func (h *HumanLayerClientWrapper) SetCallID(callID string) {
+	h.callID = callID
+}
+
+func (h *HumanLayerClientWrapper) SetRunID(runID string) {
+	h.runID = runID
+}
+
+func (h *HumanLayerClientWrapper) SetAPIKey(apiKey string) {
+	h.apiKey = apiKey
+}
+
+func (h *HumanLayerClientWrapper) RequestApproval(ctx context.Context) (functionCall *humanlayerapi.FunctionCallOutput, statusCode int, err error) {
+	channel := humanlayerapi.NewContactChannelInput()
+
+	if h.slackChannelInput != nil {
+		channel.SetSlack(*h.slackChannelInput)
+	}
+
+	if h.emailContactChannel != nil {
+		channel.SetEmail(*h.emailContactChannel)
+	}
+
+	h.functionCallSpecInput.SetChannel(*channel)
+	functionCallInput := humanlayerapi.NewFunctionCallInput(h.runID, h.callID, *h.functionCallSpecInput)
+
+	functionCall, resp, err := h.client.DefaultAPI.RequestApproval(ctx).
+		Authorization("Bearer " + h.apiKey).
+		FunctionCallInput(*functionCallInput).
+		Execute()
+
+	return functionCall, resp.StatusCode, err
 }

--- a/kubechain/internal/humanlayer/mock_hlclient.go
+++ b/kubechain/internal/humanlayer/mock_hlclient.go
@@ -1,0 +1,96 @@
+package humanlayer
+
+import (
+	"context"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+	humanlayerapi "github.com/humanlayer/smallchain/kubechain/internal/humanlayerapi"
+)
+
+// MockHumanLayerClient implements HumanLayerClientInterface for testing
+type MockHumanLayerClient struct {
+	ShouldFail    bool
+	StatusCode    int
+	ReturnError   error
+	LastAPIKey    string
+	LastCallID    string
+	LastRunID     string
+	LastFunction  string
+	LastArguments map[string]interface{}
+}
+
+// MockHumanLayerClientWrapper implements HumanLayerClientWrapperInterface for testing
+type MockHumanLayerClientWrapper struct {
+	parent       *MockHumanLayerClient
+	slackConfig  *kubechainv1alpha1.SlackChannelConfig
+	emailConfig  *kubechainv1alpha1.EmailChannelConfig
+	functionName string
+	functionArgs map[string]interface{}
+	callID       string
+	runID        string
+	apiKey       string
+}
+
+// NewHumanLayerClient creates a new mock client
+func NewMockHumanLayerClient(shouldFail bool, statusCode int, returnError error) *MockHumanLayerClient {
+	return &MockHumanLayerClient{
+		ShouldFail:  shouldFail,
+		StatusCode:  statusCode,
+		ReturnError: returnError,
+	}
+}
+
+// NewHumanLayerClient implements HumanLayerClientInterface
+func (m *MockHumanLayerClient) NewHumanLayerClient() HumanLayerClientWrapperInterface {
+	return &MockHumanLayerClientWrapper{
+		parent: m,
+	}
+}
+
+// SetSlackConfig implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) SetSlackConfig(slackConfig *kubechainv1alpha1.SlackChannelConfig) {
+	m.slackConfig = slackConfig
+}
+
+// SetEmailConfig implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) SetEmailConfig(emailConfig *kubechainv1alpha1.EmailChannelConfig) {
+	m.emailConfig = emailConfig
+}
+
+// SetFunctionCallSpec implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) SetFunctionCallSpec(functionName string, args map[string]interface{}) {
+	m.functionName = functionName
+	m.functionArgs = args
+}
+
+// SetCallID implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) SetCallID(callID string) {
+	m.callID = callID
+}
+
+// SetRunID implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) SetRunID(runID string) {
+	m.runID = runID
+}
+
+// SetAPIKey implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) SetAPIKey(apiKey string) {
+	m.apiKey = apiKey
+}
+
+// RequestApproval implements HumanLayerClientWrapperInterface
+func (m *MockHumanLayerClientWrapper) RequestApproval(ctx context.Context) (*humanlayerapi.FunctionCallOutput, int, error) {
+	// Store the values in the parent for test verification
+	m.parent.LastAPIKey = m.apiKey
+	m.parent.LastCallID = m.callID
+	m.parent.LastRunID = m.runID
+	m.parent.LastFunction = m.functionName
+	m.parent.LastArguments = m.functionArgs
+
+	if m.parent.ShouldFail {
+		return nil, m.parent.StatusCode, m.parent.ReturnError
+	}
+
+	// Return a successful mock response
+	return &humanlayerapi.FunctionCallOutput{}, m.parent.StatusCode, nil
+}


### PR DESCRIPTION
Introduces handling to transition to `AwaitingHumanApproval` and make request to HumanLayer API
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds transition to `AwaitingHumanApproval` in TaskRunToolCall with HumanLayer API integration for approval requests.
> 
>   - **Behavior**:
>     - Adds `AwaitingHumanApproval` and `ErrorRequestingHumanApproval` statuses in `taskruntoolcall_types.go`.
>     - Implements transition to `AwaitingHumanApproval` in `taskruntoolcall_controller.go`.
>     - Sends approval requests to HumanLayer API using `postToHumanLayer()`.
>     - Handles errors in HumanLayer requests, setting status to `ErrorRequestingHumanApproval`.
>   - **Controller**:
>     - Updates `TaskRunToolCallReconciler` to include `HLClient` for HumanLayer API interactions.
>     - Adds `getContactChannel()` and `getHumanLayerAPIKey()` for fetching contact channel and API key.
>     - Modifies `Reconcile()` to handle approval logic and requeue if awaiting approval.
>   - **Tests**:
>     - Adds tests in `taskruntoolcall_controller_test.go` for transitions to `AwaitingHumanApproval` and `ErrorRequestingHumanApproval`.
>     - Mocks HumanLayer client in `mock_hlclient.go` for testing API interactions.
>   - **Misc**:
>     - Updates CRD in `kubechain.humanlayer.dev_taskruntoolcalls.yaml` to include new statuses.
>     - Adds sample configuration in `kubechain_v1alpha_contactchannel_with_approval.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 9a5a14953310b57c1b2cae41d5e40051cbe2645a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->