### PR TITLE
Refactor TaskRunToolCall to separate Status and Phase concerns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,3 +437,26 @@ When designing controllers, distinguish between Status and Phase:
        })
    })
    ```
+
+#### Implementation Guidelines
+
+1. **Preserve Status During Phase Transitions**: When implementing workflow progression that only changes the Phase:
+   ```go
+   // Good: Only update Phase when transitioning to a new workflow stage
+   // while preserving current Status (health)
+   trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseAwaitingHumanApproval
+   trtc.Status.StatusDetail = "Waiting for human approval"
+   
+   // Avoid: Don't modify Status when the change is just about workflow progress
+   // trtc.Status.Status = someNewStatus // Don't do this when only the Phase is changing
+   ```
+
+2. **Change Status Only When Health State Changes**: Status should change only when the health or readiness of the resource changes:
+   ```go
+   // When a resource encounters an error
+   trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeError
+   trtc.Status.Error = err.Error()
+   
+   // When a resource becomes ready
+   trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeReady
+   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,28 +172,6 @@ Alternatively, clean up components individually:
 - Ensure the PROJECT file contains entries for all resources before running `make manifests`
 - Follow the detailed guidance in the [Kubebuilder Guide](/kubechain/docs/kubebuilder-guide.md)
 
-### Status vs Phase in Controllers
-
-When designing controllers, distinguish between Status and Phase:
-
-- **Status** indicates the health or readiness of a resource. It answers: "Is the resource working correctly?"
-  - Use StatusType values like "Ready", "Error", "Pending"
-  - Status reflects the current operational state of the resource
-  - Status changes are typically cross-cutting (error handling, initialization)
-
-- **Phase** indicates the progress of a resource in its lifecycle. It answers: "What stage of processing is the resource in?"
-  - Use PhaseType values like "Pending", "Running", "Succeeded", "Failed"
-  - Phase reflects the workflow stage of the resource
-  - Phase changes represent forward progression through a workflow
-
-- **Implementation Guidelines:**
-  - Use typed enums rather than raw strings for both Status and Phase
-  - Name test contexts using "Status:Phase -> Status:Phase" format
-  - Make status conditions explicit in controller reconciliation logic
-  - Use pattern: Pending:Pending (initialization) -> Ready:Pending (setup) -> Ready:Running (processing) -> Ready:Succeeded (completion)
-  - Use pattern: Pending:Pending (initialization) -> Ready:Pending (setup) -> Error:Failed (error handling)
-  - Keep transition logic focused and clear, with explicit condition checks in the Reconcile function
-
 ### Kubernetes Resource Design
 
 #### Don't use "config" in field names:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,3 +400,40 @@ Examples of state transition Context blocks:
 - Consider using controller runtime fake clients for complex scenarios
 - Use the `gomock` package (github.com/golang/mock/gomock) for generating mocks of interfaces
 - For HTTP services, use httptest package from the standard library
+
+### Status vs Phase in Controllers
+
+When designing controllers, distinguish between Status and Phase:
+
+- **Status** indicates the health or readiness of a resource. It answers: "Is the resource working correctly?"
+  - Use StatusType values like "Ready", "Error", "Pending", "AwaitingHumanApproval"
+  - Status reflects the current operational state of the resource
+  - Status changes are typically cross-cutting (error handling, initialization)
+  - Example values: "Ready", "Error", "Pending", "AwaitingHumanApproval", "ErrorRequestingHumanApproval"
+
+- **Phase** indicates the progress of a resource in its lifecycle. It answers: "What stage of processing is the resource in?"
+  - Use PhaseType values like "Pending", "Running", "Succeeded", "Failed", "AwaitingHumanInput"
+  - Phase reflects the workflow stage of the resource
+  - Phase changes represent forward progression through a workflow
+  - Example values: "Pending", "Running", "Succeeded", "Failed", "AwaitingHumanInput", "AwaitingSubAgent"
+
+#### Guidelines for choosing between Status and Phase
+
+1. Use **Status** for a state when:
+   - It indicates whether the resource is operational or not
+   - It represents a cross-cutting concern affecting all states (like errors)
+   - It focuses on readiness rather than progress
+
+2. Use **Phase** for a state when:
+   - It's part of a sequential progression
+   - It represents a distinct stage in a workflow
+   - It indicates what the resource is currently doing
+
+3. When naming test cases, use the "Status:Phase -> Status:Phase" format to clearly communicate transitions:
+   ```go
+   Context("Pending:Pending -> Ready:Pending", func() {
+       It("moves from Pending:Pending to Ready:Pending during setup", func() {
+           // Test implementation
+       })
+   })
+   ```

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -11,6 +11,7 @@ const (
 	TaskRunToolCallStatusTypeError            TaskRunToolCallStatusType = "Error"
 	TaskRunToolCallStatusTypePending          TaskRunToolCallStatusType = "Pending"
 	TaskRunToolCallStatusTypeToolCallRejected TaskRunToolCallStatusType = "ToolCallRejected"
+	TaskRunToolCallStatusTypeSucceeded        TaskRunToolCallStatusType = "Succeeded"
 )
 
 // TaskRunToolCallSpec defines the desired state of TaskRunToolCall
@@ -42,7 +43,7 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;ToolCallRejected
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;ToolCallRejected;Succeeded
 	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -7,11 +7,10 @@ import (
 type TaskRunToolCallStatusType string
 
 const (
-	TaskRunToolCallStatusTypeReady                        TaskRunToolCallStatusType = "Ready"
-	TaskRunToolCallStatusTypeError                        TaskRunToolCallStatusType = "Error"
-	TaskRunToolCallStatusTypePending                      TaskRunToolCallStatusType = "Pending"
-	TaskRunToolCallStatusTypeErrorRequestingHumanApproval TaskRunToolCallStatusType = "ErrorRequestingHumanApproval"
-	TaskRunToolCallStatusTypeToolCallRejected             TaskRunToolCallStatusType = "ToolCallRejected"
+	TaskRunToolCallStatusTypeReady            TaskRunToolCallStatusType = "Ready"
+	TaskRunToolCallStatusTypeError            TaskRunToolCallStatusType = "Error"
+	TaskRunToolCallStatusTypePending          TaskRunToolCallStatusType = "Pending"
+	TaskRunToolCallStatusTypeToolCallRejected TaskRunToolCallStatusType = "ToolCallRejected"
 )
 
 // TaskRunToolCallSpec defines the desired state of TaskRunToolCall
@@ -43,7 +42,7 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;ErrorRequestingHumanApproval;ToolCallRejected
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;ToolCallRejected
 	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status
@@ -75,7 +74,7 @@ type TaskRunToolCallStatus struct {
 }
 
 // TaskRunToolCallPhase represents the phase of a TaskRunToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval
 type TaskRunToolCallPhase string
 
 const (
@@ -95,6 +94,8 @@ const (
 	TaskRunToolCallPhaseAwaitingHumanApproval TaskRunToolCallPhase = "AwaitingHumanApproval"
 	// TaskRunToolCallPhaseReadyToExecuteApprovedTool indicates the tool call is ready to execute after receiving approval
 	TaskRunToolCallPhaseReadyToExecuteApprovedTool TaskRunToolCallPhase = "ReadyToExecuteApprovedTool"
+	// TaskRunToolCallPhaseErrorRequestingHumanApproval indicates there was an error requesting human approval
+	TaskRunToolCallPhaseErrorRequestingHumanApproval TaskRunToolCallPhase = "ErrorRequestingHumanApproval"
 )
 
 // +kubebuilder:object:root=true

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -7,11 +7,10 @@ import (
 type TaskRunToolCallStatusType string
 
 const (
-	TaskRunToolCallStatusTypeReady            TaskRunToolCallStatusType = "Ready"
-	TaskRunToolCallStatusTypeError            TaskRunToolCallStatusType = "Error"
-	TaskRunToolCallStatusTypePending          TaskRunToolCallStatusType = "Pending"
-	TaskRunToolCallStatusTypeToolCallRejected TaskRunToolCallStatusType = "ToolCallRejected"
-	TaskRunToolCallStatusTypeSucceeded        TaskRunToolCallStatusType = "Succeeded"
+	TaskRunToolCallStatusTypeReady     TaskRunToolCallStatusType = "Ready"
+	TaskRunToolCallStatusTypeError     TaskRunToolCallStatusType = "Error"
+	TaskRunToolCallStatusTypePending   TaskRunToolCallStatusType = "Pending"
+	TaskRunToolCallStatusTypeSucceeded TaskRunToolCallStatusType = "Succeeded"
 )
 
 // TaskRunToolCallSpec defines the desired state of TaskRunToolCall
@@ -43,7 +42,7 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;ToolCallRejected;Succeeded
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;Succeeded
 	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status
@@ -75,7 +74,7 @@ type TaskRunToolCallStatus struct {
 }
 
 // TaskRunToolCallPhase represents the phase of a TaskRunToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval;ToolCallRejected
 type TaskRunToolCallPhase string
 
 const (
@@ -97,6 +96,8 @@ const (
 	TaskRunToolCallPhaseReadyToExecuteApprovedTool TaskRunToolCallPhase = "ReadyToExecuteApprovedTool"
 	// TaskRunToolCallPhaseErrorRequestingHumanApproval indicates there was an error requesting human approval
 	TaskRunToolCallPhaseErrorRequestingHumanApproval TaskRunToolCallPhase = "ErrorRequestingHumanApproval"
+	// TaskRunToolCallPhaseToolCallRejected indicates the tool call was rejected by human approval
+	TaskRunToolCallPhaseToolCallRejected TaskRunToolCallPhase = "ToolCallRejected"
 )
 
 // +kubebuilder:object:root=true

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -11,8 +11,6 @@ const (
 	TaskRunToolCallStatusTypeError                        TaskRunToolCallStatusType = "Error"
 	TaskRunToolCallStatusTypePending                      TaskRunToolCallStatusType = "Pending"
 	TaskRunToolCallStatusTypeAwaitingHumanApproval        TaskRunToolCallStatusType = "AwaitingHumanApproval"
-	TaskRunToolCallStatusTypeAwaitingHumanInput           TaskRunToolCallStatusType = "AwaitingHumanInput"
-	TaskRunToolCallStatusTypeAwaitingSubAgent             TaskRunToolCallStatusType = "AwaitingSubAgent"
 	TaskRunToolCallStatusTypeErrorRequestingHumanApproval TaskRunToolCallStatusType = "ErrorRequestingHumanApproval"
 	TaskRunToolCallStatusTypeReadyToExecuteApprovedTool   TaskRunToolCallStatusType = "ReadyToExecuteApprovedTool"
 	TaskRunToolCallStatusTypeToolCallRejected             TaskRunToolCallStatusType = "ToolCallRejected"
@@ -47,7 +45,7 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;AwaitingHumanApproval;AwaitingHumanInput;AwaitingSubAgent;ErrorRequestingHumanApproval;ReadyToExecuteApprovedTool;ToolCallRejected
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;AwaitingHumanApproval;ErrorRequestingHumanApproval;ReadyToExecuteApprovedTool;ToolCallRejected
 	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status
@@ -79,7 +77,7 @@ type TaskRunToolCallStatus struct {
 }
 
 // TaskRunToolCallPhase represents the phase of a TaskRunToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent
 type TaskRunToolCallPhase string
 
 const (
@@ -91,6 +89,10 @@ const (
 	TaskRunToolCallPhaseSucceeded TaskRunToolCallPhase = "Succeeded"
 	// TaskRunToolCallPhaseFailed indicates the tool call failed
 	TaskRunToolCallPhaseFailed TaskRunToolCallPhase = "Failed"
+	// TaskRunToolCallPhaseAwaitingHumanInput indicates the tool call is waiting for human input
+	TaskRunToolCallPhaseAwaitingHumanInput TaskRunToolCallPhase = "AwaitingHumanInput"
+	// TaskRunToolCallPhaseAwaitingSubAgent indicates the tool call is waiting for a sub-agent to complete
+	TaskRunToolCallPhaseAwaitingSubAgent TaskRunToolCallPhase = "AwaitingSubAgent"
 )
 
 // +kubebuilder:object:root=true

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -11,7 +11,6 @@ const (
 	TaskRunToolCallStatusTypeError                        TaskRunToolCallStatusType = "Error"
 	TaskRunToolCallStatusTypePending                      TaskRunToolCallStatusType = "Pending"
 	TaskRunToolCallStatusTypeErrorRequestingHumanApproval TaskRunToolCallStatusType = "ErrorRequestingHumanApproval"
-	TaskRunToolCallStatusTypeReadyToExecuteApprovedTool   TaskRunToolCallStatusType = "ReadyToExecuteApprovedTool"
 	TaskRunToolCallStatusTypeToolCallRejected             TaskRunToolCallStatusType = "ToolCallRejected"
 )
 
@@ -44,7 +43,7 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;ErrorRequestingHumanApproval;ReadyToExecuteApprovedTool;ToolCallRejected
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;ErrorRequestingHumanApproval;ToolCallRejected
 	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status
@@ -76,7 +75,7 @@ type TaskRunToolCallStatus struct {
 }
 
 // TaskRunToolCallPhase represents the phase of a TaskRunToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool
 type TaskRunToolCallPhase string
 
 const (
@@ -94,6 +93,8 @@ const (
 	TaskRunToolCallPhaseAwaitingSubAgent TaskRunToolCallPhase = "AwaitingSubAgent"
 	// TaskRunToolCallPhaseAwaitingHumanApproval indicates the tool call is waiting for human approval
 	TaskRunToolCallPhaseAwaitingHumanApproval TaskRunToolCallPhase = "AwaitingHumanApproval"
+	// TaskRunToolCallPhaseReadyToExecuteApprovedTool indicates the tool call is ready to execute after receiving approval
+	TaskRunToolCallPhaseReadyToExecuteApprovedTool TaskRunToolCallPhase = "ReadyToExecuteApprovedTool"
 )
 
 // +kubebuilder:object:root=true

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -10,7 +10,6 @@ const (
 	TaskRunToolCallStatusTypeReady                        TaskRunToolCallStatusType = "Ready"
 	TaskRunToolCallStatusTypeError                        TaskRunToolCallStatusType = "Error"
 	TaskRunToolCallStatusTypePending                      TaskRunToolCallStatusType = "Pending"
-	TaskRunToolCallStatusTypeAwaitingHumanApproval        TaskRunToolCallStatusType = "AwaitingHumanApproval"
 	TaskRunToolCallStatusTypeErrorRequestingHumanApproval TaskRunToolCallStatusType = "ErrorRequestingHumanApproval"
 	TaskRunToolCallStatusTypeReadyToExecuteApprovedTool   TaskRunToolCallStatusType = "ReadyToExecuteApprovedTool"
 	TaskRunToolCallStatusTypeToolCallRejected             TaskRunToolCallStatusType = "ToolCallRejected"
@@ -45,7 +44,7 @@ type TaskRunToolCallStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Status indicates the current status of the tool call
-	// +kubebuilder:validation:Enum=Ready;Error;Pending;AwaitingHumanApproval;ErrorRequestingHumanApproval;ReadyToExecuteApprovedTool;ToolCallRejected
+	// +kubebuilder:validation:Enum=Ready;Error;Pending;ErrorRequestingHumanApproval;ReadyToExecuteApprovedTool;ToolCallRejected
 	Status TaskRunToolCallStatusType `json:"status,omitempty"`
 
 	// StatusDetail provides additional details about the current status
@@ -77,7 +76,7 @@ type TaskRunToolCallStatus struct {
 }
 
 // TaskRunToolCallPhase represents the phase of a TaskRunToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval
 type TaskRunToolCallPhase string
 
 const (
@@ -93,6 +92,8 @@ const (
 	TaskRunToolCallPhaseAwaitingHumanInput TaskRunToolCallPhase = "AwaitingHumanInput"
 	// TaskRunToolCallPhaseAwaitingSubAgent indicates the tool call is waiting for a sub-agent to complete
 	TaskRunToolCallPhaseAwaitingSubAgent TaskRunToolCallPhase = "AwaitingSubAgent"
+	// TaskRunToolCallPhaseAwaitingHumanApproval indicates the tool call is waiting for human approval
+	TaskRunToolCallPhaseAwaitingHumanApproval TaskRunToolCallPhase = "AwaitingHumanApproval"
 )
 
 // +kubebuilder:object:root=true

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -118,6 +118,7 @@ spec:
                 - AwaitingSubAgent
                 - AwaitingHumanApproval
                 - ReadyToExecuteApprovedTool
+                - ErrorRequestingHumanApproval
                 type: string
               ready:
                 description: Ready indicates if the tool call is ready to be executed
@@ -145,7 +146,6 @@ spec:
                 - Ready
                 - Error
                 - Pending
-                - ErrorRequestingHumanApproval
                 - ToolCallRejected
                 type: string
               statusDetail:

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -117,6 +117,7 @@ spec:
                 - AwaitingHumanInput
                 - AwaitingSubAgent
                 - AwaitingHumanApproval
+                - ReadyToExecuteApprovedTool
                 type: string
               ready:
                 description: Ready indicates if the tool call is ready to be executed
@@ -145,7 +146,6 @@ spec:
                 - Error
                 - Pending
                 - ErrorRequestingHumanApproval
-                - ReadyToExecuteApprovedTool
                 - ToolCallRejected
                 type: string
               statusDetail:

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -116,6 +116,7 @@ spec:
                 - Failed
                 - AwaitingHumanInput
                 - AwaitingSubAgent
+                - AwaitingHumanApproval
                 type: string
               ready:
                 description: Ready indicates if the tool call is ready to be executed
@@ -143,7 +144,6 @@ spec:
                 - Ready
                 - Error
                 - Pending
-                - AwaitingHumanApproval
                 - ErrorRequestingHumanApproval
                 - ReadyToExecuteApprovedTool
                 - ToolCallRejected

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -147,6 +147,7 @@ spec:
                 - Error
                 - Pending
                 - ToolCallRejected
+                - Succeeded
                 type: string
               statusDetail:
                 description: StatusDetail provides additional details about the current

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -119,6 +119,7 @@ spec:
                 - AwaitingHumanApproval
                 - ReadyToExecuteApprovedTool
                 - ErrorRequestingHumanApproval
+                - ToolCallRejected
                 type: string
               ready:
                 description: Ready indicates if the tool call is ready to be executed
@@ -146,7 +147,6 @@ spec:
                 - Ready
                 - Error
                 - Pending
-                - ToolCallRejected
                 - Succeeded
                 type: string
               statusDetail:

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -114,6 +114,8 @@ spec:
                 - Running
                 - Succeeded
                 - Failed
+                - AwaitingHumanInput
+                - AwaitingSubAgent
                 type: string
               ready:
                 description: Ready indicates if the tool call is ready to be executed
@@ -142,8 +144,6 @@ spec:
                 - Error
                 - Pending
                 - AwaitingHumanApproval
-                - AwaitingHumanInput
-                - AwaitingSubAgent
                 - ErrorRequestingHumanApproval
                 - ReadyToExecuteApprovedTool
                 - ToolCallRejected

--- a/kubechain/config/manager/kustomization.yaml
+++ b/kubechain/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: controller
-  newTag: "202504012152"
+  newTag: "202504021329"

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -101,8 +101,8 @@ func (r *TaskRunToolCallReconciler) updateTaskRunToolCall(ctx context.Context, w
 			trtc.Status.StatusDetail = DetailToolExecutedSuccess
 		} else {
 			trtc.Status.Result = "Rejected"
-			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseFailed
-			trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeError
+			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseToolCallRejected
+			trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded
 			trtc.Status.StatusDetail = "Tool execution rejected"
 		}
 
@@ -724,7 +724,8 @@ func (r *TaskRunToolCallReconciler) updateTRTCStatus(ctx context.Context, trtc *
 	trtcDeepCopy.Status.StatusDetail = statusDetail
 	trtcDeepCopy.Status.Phase = trtcStatusPhase
 
-	if trtcStatusType == kubechainv1alpha1.TaskRunToolCallStatusTypeToolCallRejected {
+	// Store the result for tool call rejection
+	if trtcStatusPhase == kubechainv1alpha1.TaskRunToolCallPhaseToolCallRejected {
 		trtcDeepCopy.Status.Result = result
 	}
 
@@ -808,8 +809,8 @@ func (r *TaskRunToolCallReconciler) handlePendingApproval(ctx context.Context, t
 			"Ready to execute approved tool", "")
 	} else {
 		return r.updateTRTCStatus(ctx, trtc,
-			kubechainv1alpha1.TaskRunToolCallStatusTypeToolCallRejected,
-			kubechainv1alpha1.TaskRunToolCallPhaseFailed,
+			kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded,
+			kubechainv1alpha1.TaskRunToolCallPhaseToolCallRejected,
 			"Tool execution rejected", status.GetComment())
 	}
 }

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -207,12 +207,6 @@ func (r *TaskRunToolCallReconciler) completeSetup(ctx context.Context, trtc *kub
 func (r *TaskRunToolCallReconciler) checkCompletedOrExisting(ctx context.Context, trtc *kubechainv1alpha1.TaskRunToolCall) (completed bool, err error, handled bool) {
 	logger := log.FromContext(ctx)
 
-	// Check if already completed
-	if trtc.Status.Phase == kubechainv1alpha1.TaskRunToolCallPhaseSucceeded || trtc.Status.Phase == kubechainv1alpha1.TaskRunToolCallPhaseFailed {
-		logger.Info("TaskRunToolCall already completed, nothing to do", "phase", trtc.Status.Phase)
-		return true, nil, true
-	}
-
 	// Check if a child TaskRun already exists for this tool call
 	var taskRunList kubechainv1alpha1.TaskRunList
 	if err := r.List(ctx, &taskRunList, client.InNamespace(trtc.Namespace), client.MatchingLabels{"kubechain.humanlayer.dev/taskruntoolcall": trtc.Name}); err != nil {

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -230,6 +230,7 @@ func (r *TaskRunToolCallReconciler) parseArguments(ctx context.Context, trtc *ku
 	if err := json.Unmarshal([]byte(trtc.Spec.Arguments), &args); err != nil {
 		logger.Error(err, "Failed to parse arguments")
 		trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeError
+		trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseFailed
 		trtc.Status.StatusDetail = DetailInvalidArgsJSON
 		trtc.Status.Error = err.Error()
 		r.recorder.Event(trtc, corev1.EventTypeWarning, "ExecutionFailed", err.Error())

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -799,8 +799,8 @@ func (r *TaskRunToolCallReconciler) handlePendingApproval(ctx context.Context, t
 
 	if *approved {
 		return r.updateTRTCStatus(ctx, trtc,
-			kubechainv1alpha1.TaskRunToolCallStatusTypeReadyToExecuteApprovedTool,
-			kubechainv1alpha1.TaskRunToolCallPhasePending,
+			kubechainv1alpha1.TaskRunToolCallStatusTypeReady,
+			kubechainv1alpha1.TaskRunToolCallPhaseReadyToExecuteApprovedTool,
 			"Ready to execute approved tool", "")
 	} else {
 		return r.updateTRTCStatus(ctx, trtc,
@@ -817,7 +817,7 @@ func (r *TaskRunToolCallReconciler) requestHumanApproval(ctx context.Context, tr
 	logger := log.FromContext(ctx)
 
 	// Skip if already in progress or approved
-	if trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeReadyToExecuteApprovedTool {
+	if trtc.Status.Phase == kubechainv1alpha1.TaskRunToolCallPhaseReadyToExecuteApprovedTool {
 		return ctrl.Result{}, nil
 	}
 
@@ -866,7 +866,7 @@ func (r *TaskRunToolCallReconciler) requestHumanApproval(ctx context.Context, tr
 // handleMCPApprovalFlow encapsulates the MCP approval flow logic
 func (r *TaskRunToolCallReconciler) handleMCPApprovalFlow(ctx context.Context, trtc *kubechainv1alpha1.TaskRunToolCall) (result ctrl.Result, err error, handled bool) {
 	// We've already been through the approval flow and are ready to execute the tool
-	if trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeReadyToExecuteApprovedTool {
+	if trtc.Status.Phase == kubechainv1alpha1.TaskRunToolCallPhaseReadyToExecuteApprovedTool {
 		return ctrl.Result{}, nil, false
 	}
 

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -97,7 +97,7 @@ func (r *TaskRunToolCallReconciler) updateTaskRunToolCall(ctx context.Context, w
 		if *webhook.Status.Approved {
 			trtc.Status.Result = "Approved"
 			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
-			trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeReady
+			trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded
 			trtc.Status.StatusDetail = DetailToolExecutedSuccess
 		} else {
 			trtc.Status.Result = "Rejected"
@@ -167,7 +167,7 @@ func (r *TaskRunToolCallReconciler) executeMCPTool(ctx context.Context, trtc *ku
 	// Update TaskRunToolCall status with the MCP tool result
 	trtc.Status.Result = result
 	trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
-	trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeReady
+	trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded
 	trtc.Status.StatusDetail = "MCP tool executed successfully"
 
 	return nil
@@ -431,7 +431,7 @@ func (r *TaskRunToolCallReconciler) processBuiltinFunction(ctx context.Context, 
 	// Update TaskRunToolCall status with the function result
 	trtc.Status.Result = fmt.Sprintf("%v", res)
 	trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
-	trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeReady
+	trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded
 	trtc.Status.StatusDetail = DetailToolExecutedSuccess
 	if err := r.Status().Update(ctx, trtc); err != nil {
 		logger.Error(err, "Failed to update TaskRunToolCall status after execution")
@@ -602,7 +602,7 @@ func (r *TaskRunToolCallReconciler) processExternalAPI(ctx context.Context, trtc
 
 	// Update TaskRunToolCall with the result
 	trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
-	trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeReady
+	trtc.Status.Status = kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded
 	trtc.Status.StatusDetail = DetailToolExecutedSuccess
 	if err := r.Status().Update(ctx, trtc); err != nil {
 		logger.Error(err, "Failed to update TaskRunToolCall status")
@@ -958,9 +958,10 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	logger.Info("Reconciling TaskRunToolCall", "name", trtc.Name)
 
-	// 1. Check for terminal error states - early return
-	if trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeError {
-		logger.Info("TaskRunToolCall in error state, nothing to do", "status", trtc.Status.Status, "phase", trtc.Status.Phase)
+	// 1. Check for terminal states - early return
+	if trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeError ||
+		trtc.Status.Status == kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded {
+		logger.Info("TaskRunToolCall in terminal state, nothing to do", "status", trtc.Status.Status, "phase", trtc.Status.Phase)
 		return ctrl.Result{}, nil
 	}
 

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -375,8 +375,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
-	Context("Ready:AwaitingHumanApproval -> Ready:Pending", func() {
-		It("transitions from Ready:AwaitingHumanApproval to ReadyToExecuteApprovedTool status when MCP tool is approved", func() {
+	Context("Ready:AwaitingHumanApproval -> Ready:ReadyToExecuteApprovedTool", func() {
+		It("transitions from Ready:AwaitingHumanApproval to Ready:ReadyToExecuteApprovedTool when MCP tool is approved", func() {
 			trtc, teardown := setupTestApprovalResources(ctx, &SetupTestApprovalConfig{
 				TaskRunToolCallStatus: &kubechainv1alpha1.TaskRunToolCallStatus{
 					ExternalCallID: "call-ready-to-execute-test",
@@ -421,8 +421,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			}, updatedTRTC)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhasePending))
-			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeReadyToExecuteApprovedTool))
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseReadyToExecuteApprovedTool))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeReady))
 			Expect(updatedTRTC.Status.StatusDetail).To(ContainSubstring("Ready to execute approved tool"))
 		})
 	})
@@ -483,13 +483,13 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
-	Context("ReadyToExecuteApprovedTool -> Succeeded", func() {
-		It("transitions from ReadyToExecuteApprovedTool to Succeeded when a tool is executed", func() {
+	Context("Ready:ReadyToExecuteApprovedTool -> Ready:Succeeded", func() {
+		It("transitions from Ready:ReadyToExecuteApprovedTool to Ready:Succeeded when a tool is executed", func() {
 			trtc, teardown := setupTestApprovalResources(ctx, &SetupTestApprovalConfig{
 				TaskRunToolCallStatus: &kubechainv1alpha1.TaskRunToolCallStatus{
 					ExternalCallID: "call-ready-to-execute-test",
-					Phase:          kubechainv1alpha1.TaskRunToolCallPhasePending,
-					Status:         kubechainv1alpha1.TaskRunToolCallStatusTypeReadyToExecuteApprovedTool,
+					Phase:          kubechainv1alpha1.TaskRunToolCallPhaseReadyToExecuteApprovedTool,
+					Status:         kubechainv1alpha1.TaskRunToolCallStatusTypeReady,
 					StatusDetail:   "Ready to execute tool, with great vigor",
 					StartTime:      &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
 				},

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -91,8 +91,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
-	Context("Ready:Pending -> Ready:Succeeded", func() {
-		It("moves to Succeeded after executing a simple function tool call", func() {
+	Context("Ready:Pending -> Succeeded:Succeeded", func() {
+		It("moves to Succeeded:Succeeded after executing a simple function tool call", func() {
 			ctx := context.Background()
 
 			teardown := setupTestAddTool(ctx)
@@ -128,7 +128,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
 			Expect(updatedTRTC.Status.Result).To(Equal("5")) // 2 + 3 = 5
-			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeReady))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded))
 			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Tool executed successfully"))
 
 			By("checking that execution events were emitted")
@@ -190,7 +190,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 	})
 
 	// Tests for MCP tools without approval requirement
-	Context("Pending:Pending -> Ready:Succeeded (MCP Tool)", func() {
+	Context("Pending:Pending -> Succeeded:Succeeded (MCP Tool)", func() {
 		It("successfully executes an MCP tool without requiring approval", func() {
 			// Setup MCP server without approval channel
 			testSecret.Setup(ctx)
@@ -256,7 +256,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
-			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeReady))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded))
 			Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
 
 			By("checking that appropriate events were emitted")
@@ -483,8 +483,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
-	Context("Ready:ReadyToExecuteApprovedTool -> Ready:Succeeded", func() {
-		It("transitions from Ready:ReadyToExecuteApprovedTool to Ready:Succeeded when a tool is executed", func() {
+	Context("Ready:ReadyToExecuteApprovedTool -> Succeeded:Succeeded", func() {
+		It("transitions from Ready:ReadyToExecuteApprovedTool to Succeeded:Succeeded when a tool is executed", func() {
 			trtc, teardown := setupTestApprovalResources(ctx, &SetupTestApprovalConfig{
 				TaskRunToolCallStatus: &kubechainv1alpha1.TaskRunToolCallStatus{
 					ExternalCallID: "call-ready-to-execute-test",
@@ -519,7 +519,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseSucceeded))
-			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeReady))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded))
 			Expect(updatedTRTC.Status.Result).To(Equal("5")) // From our mock implementation
 		})
 	})

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -524,8 +524,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
-	Context("Pending -> ErrorRequestingHumanApproval (MCP Tool)", func() {
-		It("transitions to ErrorRequestingHumanApproval when request to HumanLayer fails", func() {
+	Context("Ready:Pending -> Error:ErrorRequestingHumanApproval (MCP Tool)", func() {
+		It("transitions to Error:ErrorRequestingHumanApproval when request to HumanLayer fails", func() {
 			// Note setupTestApprovalResources sets up the MCP server, MCP tool, and TaskRunToolCall
 			trtc, teardown := setupTestApprovalResources(ctx, nil)
 			defer teardown()
@@ -553,7 +553,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
 
-			By("checking the taskruntoolcall status is set to ErrorRequestingHumanApproval")
+			By("checking the taskruntoolcall has ErrorRequestingHumanApproval phase and Error status")
 			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      trtc.Name,
@@ -561,8 +561,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			}, updatedTRTC)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseAwaitingHumanApproval))
-			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeErrorRequestingHumanApproval))
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseErrorRequestingHumanApproval))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeError))
 		})
 	})
 })

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -427,8 +427,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
-	Context("Ready:AwaitingHumanApproval -> ToolCallRejected", func() {
-		It("transitions from Ready:AwaitingHumanApproval to ToolCallRejected when MCP tool is rejected", func() {
+	Context("Ready:AwaitingHumanApproval -> Succeeded:ToolCallRejected", func() {
+		It("transitions from Ready:AwaitingHumanApproval to Succeeded:ToolCallRejected when MCP tool is rejected", func() {
 			trtc, teardown := setupTestApprovalResources(ctx, &SetupTestApprovalConfig{
 				TaskRunToolCallStatus: &kubechainv1alpha1.TaskRunToolCallStatus{
 					ExternalCallID: "call-tool-call-rejected-test",
@@ -468,7 +468,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
 
-			By("checking the taskruntoolcall status is set to ToolCallRejected")
+			By("checking the taskruntoolcall has ToolCallRejected phase and Succeeded status")
 			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      trtc.Name,
@@ -476,8 +476,8 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 			}, updatedTRTC)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseFailed))
-			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeToolCallRejected))
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseToolCallRejected))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeSucceeded))
 			Expect(updatedTRTC.Status.StatusDetail).To(ContainSubstring("Tool execution rejected"))
 			Expect(updatedTRTC.Status.Result).To(Equal(rejectionComment))
 		})

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -179,8 +179,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeError))
-			// TODO: Is this the right Phase for this case?
-			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhasePending))
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseFailed))
 			Expect(updatedTRTC.Status.StatusDetail).To(Equal("Invalid arguments JSON"))
 			Expect(updatedTRTC.Status.Error).NotTo(BeEmpty())
 

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -435,8 +435,8 @@ func setupTestApprovalResources(ctx context.Context, config *SetupTestApprovalCo
 
 	status := kubechainv1alpha1.TaskRunToolCallStatus{
 		Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
-		Status:       "Pending",
-		StatusDetail: "Ready for execution",
+		Status:       kubechainv1alpha1.TaskRunToolCallStatusTypeReady,
+		StatusDetail: "Setup complete",
 		StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
 	}
 


### PR DESCRIPTION
##  Refactor `TaskRunToolCall`'s use of `Status` and `Phase`

### Summary

This PR implements a comprehensive refactoring of the TaskRunToolCall controller to properly separate operational status (health) from workflow phases (progress).

### Changes

- Completely refactored `TaskRunToolCall` controller to clarify Status vs Phase distinction
- Moved workflow states from Status to Phase (`AwaitingHumanInput`, `AwaitingSubAgent`, `AwaitingHumanApproval`, `ReadyToExecuteApprovedTool`, `ErrorRequestingHumanApproval`, `ToolCallRejected`)
- Added `TaskRunToolCallStatusTypeSucceeded` as a terminal state, used for both successful execution and rejection scenarios
- Refactored controller code to maintain clear separation between `Status` and `Phase` transitions
- Added early return for terminal states to improve efficiency
- Added proper Status checks in reconciliation logic for consistent processing
- Updated tests to follow the "Status:Phase -> Status:Phase" naming convention
- Added comprehensive documentation on the Status vs Phase pattern for controllers

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `TaskRunToolCall` to separate `Status` and `Phase` concerns, updating controller logic, models, and tests for clarity and efficiency.
> 
>   - **Behavior**:
>     - Refactor `TaskRunToolCall` controller to separate `Status` and `Phase` concerns, improving clarity and efficiency.
>     - Add `TaskRunToolCallStatusTypeSucceeded` as a terminal state for successful execution and rejection scenarios.
>     - Implement early return for terminal states in `taskruntoolcall_controller.go`.
>   - **Models**:
>     - Move workflow states from `Status` to `Phase` in `taskruntoolcall_types.go`.
>     - Update CRD in `kubechain.humanlayer.dev_taskruntoolcalls.yaml` to reflect new `Status` and `Phase` values.
>   - **Tests**:
>     - Update tests in `taskruntoolcall_controller_test.go` and `utils_test.go` to follow "Status:Phase -> Status:Phase" naming convention.
>     - Add tests for new `Status` and `Phase` transitions.
>   - **Documentation**:
>     - Add comprehensive documentation on `Status` vs `Phase` pattern in `CLAUDE.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 67a77286b6410c0787924356a5c0ee3185a1ac84. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->