### PR TITLE
Transition to Failed status phase in TaskRun on 4xx

### DIFF
--- a/kubechain/internal/controller/taskrun/taskrun_controller_test.go
+++ b/kubechain/internal/controller/taskrun/taskrun_controller_test.go
@@ -217,7 +217,93 @@ var _ = Describe("TaskRun Controller", func() {
 		})
 	})
 	Context("ReadyForLLM -> Error", func() {
-		XIt("moves to Error if the LLM returns an error", func() {})
+		It("moves to Error state but not Failed phase on general error", func() {
+			_, _, _, _, teardown := setupSuiteObjects(ctx)
+			defer teardown()
+
+			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
+				Phase: kubechain.TaskRunPhaseReadyForLLM,
+				ContextWindow: []kubechain.Message{
+					{
+						Role:    "system",
+						Content: testAgent.system,
+					},
+					{
+						Role:    "user",
+						Content: testTask.message,
+					},
+				},
+			})
+			defer testTaskRun.Teardown(ctx)
+
+			By("reconciling the taskrun with a mock LLM client that returns an error")
+			reconciler, recorder := reconciler()
+			mockLLMClient := &llmclient.MockRawOpenAIClient{
+				Error: fmt.Errorf("connection timeout"),
+			}
+			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
+				return mockLLMClient, nil
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("checking the taskrun status")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
+			Expect(taskRun.Status.Status).To(Equal(kubechain.TaskRunStatusStatusError))
+			// Phase shouldn't be Failed for general errors
+			Expect(taskRun.Status.Phase).ToNot(Equal(kubechain.TaskRunPhaseFailed))
+			Expect(taskRun.Status.Error).To(Equal("connection timeout"))
+			ExpectRecorder(recorder).ToEmitEventContaining("LLMRequestFailed")
+		})
+
+		It("moves to Error state AND Failed phase on 4xx error", func() {
+			_, _, _, _, teardown := setupSuiteObjects(ctx)
+			defer teardown()
+
+			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
+				Phase: kubechain.TaskRunPhaseReadyForLLM,
+				ContextWindow: []kubechain.Message{
+					{
+						Role:    "system",
+						Content: testAgent.system,
+					},
+					{
+						Role:    "user",
+						Content: testTask.message,
+					},
+				},
+			})
+			defer testTaskRun.Teardown(ctx)
+
+			By("reconciling the taskrun with a mock LLM client that returns a 400 error")
+			reconciler, recorder := reconciler()
+			mockLLMClient := &llmclient.MockRawOpenAIClient{
+				Error: &llmclient.LLMRequestError{
+					StatusCode: 400,
+					Message:    "invalid request: model not found",
+					Err:        fmt.Errorf("OpenAI API request failed"),
+				},
+			}
+			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
+				return mockLLMClient, nil
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("checking the taskrun status")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
+			Expect(taskRun.Status.Status).To(Equal(kubechain.TaskRunStatusStatusError))
+			// Phase should be Failed for 4xx errors
+			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseFailed))
+			Expect(taskRun.Status.Error).To(ContainSubstring("LLM request failed with status 400"))
+			ExpectRecorder(recorder).ToEmitEventContaining("LLMRequestFailed4xx")
+		})
 	})
 	Context("Error -> ErrorBackoff", func() {
 		XIt("moves to ErrorBackoff if the error is retryable", func() {})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR updates `TaskRun` to transition to a Failed phase on 4xx LLM request errors, with new error handling and tests.
> 
>   - **Behavior**:
>     - In `taskrun_controller.go`, `Reconcile()` now transitions `TaskRun` to `Failed` phase on 4xx errors from LLM requests, using `LLMRequestError`.
>     - Logs 4xx errors with `LLMRequestFailed4xx` event.
>   - **Error Handling**:
>     - Adds `LLMRequestError` in `openai_client.go` to encapsulate HTTP status codes and messages.
>     - `SendRequest()` in `openai_client.go` returns `LLMRequestError` for non-200 responses.
>   - **Testing**:
>     - Adds tests in `taskrun_controller_test.go` for 4xx error handling, ensuring `TaskRun` transitions to `Failed` phase.
>     - Verifies event logging for 4xx errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 8a12759ade1e12c13cbdb2edace885dc443584d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->