### PR TITLE
Manage multi-tool scenarios by providing unique resource name and stamping tool request sets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,7 @@ Examples of state transition Context blocks:
 - Use descriptive By() statements to explain test steps
 - Ensure each test verifies both the state and any side effects
 - Assert on specific fields that should change during the transition
+- Use positive assertions (prefer `Expect(x).To(Equal(y))` over `Expect(x).NotTo(Equal(z))`) for clarity and readability
 - Test event recording when events are part of the controller behavior
 - Verify controller return values (Requeue, RequeueAfter)
 - For tool calls or API interactions, use mock clients with verification

--- a/kubechain/api/v1alpha1/taskrun_types.go
+++ b/kubechain/api/v1alpha1/taskrun_types.go
@@ -121,6 +121,10 @@ type TaskRunStatus struct {
 	// SpanContext contains OpenTelemetry span context information
 	// +optional
 	SpanContext *SpanContext `json:"spanContext,omitempty"`
+
+	// ToolCallRequestId uniquely identifies a set of tool calls from a single LLM response
+	// +optional
+	ToolCallRequestId string `json:"toolCallRequestId,omitempty"`
 }
 
 type TaskRunStatusStatus string

--- a/kubechain/api/v1alpha1/taskrun_types.go
+++ b/kubechain/api/v1alpha1/taskrun_types.go
@@ -122,9 +122,9 @@ type TaskRunStatus struct {
 	// +optional
 	SpanContext *SpanContext `json:"spanContext,omitempty"`
 
-	// ToolCallRequestId uniquely identifies a set of tool calls from a single LLM response
+	// ToolCallRequestID uniquely identifies a set of tool calls from a single LLM response
 	// +optional
-	ToolCallRequestId string `json:"toolCallRequestId,omitempty"`
+	ToolCallRequestID string `json:"toolCallRequestId,omitempty"`
 }
 
 type TaskRunStatusStatus string

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruns.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruns.yaml
@@ -232,6 +232,10 @@ spec:
                 description: StatusDetail provides additional details about the current
                   status
                 type: string
+              toolCallRequestId:
+                description: ToolCallRequestId uniquely identifies a set of tool calls
+                  from a single LLM response
+                type: string
               userMsgPreview:
                 description: UserMsgPreview stores the first 50 characters of the
                   user's message

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruns.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruns.yaml
@@ -233,7 +233,7 @@ spec:
                   status
                 type: string
               toolCallRequestId:
-                description: ToolCallRequestId uniquely identifies a set of tool calls
+                description: ToolCallRequestID uniquely identifies a set of tool calls
                   from a single LLM response
                 type: string
               userMsgPreview:

--- a/kubechain/internal/controller/taskrun/taskrun_controller_test.go
+++ b/kubechain/internal/controller/taskrun/taskrun_controller_test.go
@@ -190,12 +190,10 @@ var _ = Describe("TaskRun Controller", func() {
 
 			By("creating a reconciler with a mock OpenAI client")
 			reconciler, recorder := reconciler()
-			mockClient := &MockOpenAIClient{
-				SendRequestFunc: func(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error) {
-					return &kubechain.Message{
-						Role:    "assistant",
-						Content: "The moon does not have a capital.",
-					}, nil
+			mockClient := &llmclient.MockRawOpenAIClient{
+				Response: &kubechain.Message{
+					Role:    "assistant",
+					Content: "The moon does not have a capital.",
 				},
 			}
 			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
@@ -243,20 +241,18 @@ var _ = Describe("TaskRun Controller", func() {
 
 			By("creating a reconciler with a mock OpenAI client that returns tools")
 			reconciler, recorder := reconciler()
-			mockClient := &MockOpenAIClient{
-				SendRequestFunc: func(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error) {
-					return &kubechain.Message{
-						Role: "assistant",
-						ToolCalls: []kubechain.ToolCall{
-							{
-								ID: "1",
-								Function: kubechain.ToolCallFunction{
-									Name:      "fetch__fetch",
-									Arguments: `{"url": "https://api.example.com/data"}`,
-								},
+			mockClient := &llmclient.MockRawOpenAIClient{
+				Response: &kubechain.Message{
+					Role: "assistant",
+					ToolCalls: []kubechain.ToolCall{
+						{
+							ID: "1",
+							Function: kubechain.ToolCallFunction{
+								Name:      "fetch__fetch",
+								Arguments: `{"url": "https://api.example.com/data"}`,
 							},
 						},
-					}, nil
+					},
 				},
 			}
 			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
@@ -389,14 +385,7 @@ var _ = Describe("TaskRun Controller", func() {
 	})
 })
 
-// Mock OpenAI client for testing
-type MockOpenAIClient struct {
-	SendRequestFunc func(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error)
-}
-
-func (m *MockOpenAIClient) SendRequest(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error) {
-	return m.SendRequestFunc(ctx, messages, tools)
-}
+// We're using the MockRawOpenAIClient from the llmclient package instead of a local mock
 
 // These tests are currently disabled to focus on the current implementation
 var _ = PDescribe("TaskRun Controller", func() {

--- a/kubechain/internal/controller/taskrun/taskrun_controller_test.go
+++ b/kubechain/internal/controller/taskrun/taskrun_controller_test.go
@@ -10,10 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	kubechain "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	"github.com/humanlayer/smallchain/kubechain/internal/llmclient"
-	. "github.com/humanlayer/smallchain/kubechain/test/utils"
 )
 
 var _ = Describe("TaskRun Controller", func() {

--- a/kubechain/internal/controller/taskrun/taskrun_controller_test.go
+++ b/kubechain/internal/controller/taskrun/taskrun_controller_test.go
@@ -376,7 +376,7 @@ var _ = Describe("TaskRun Controller", func() {
 
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
 				Phase:             kubechain.TaskRunPhaseToolCallsPending,
-				ToolCallRequestId: "test123",
+				ToolCallRequestID: "test123",
 			})
 			defer testTaskRun.Teardown(ctx)
 
@@ -407,7 +407,7 @@ var _ = Describe("TaskRun Controller", func() {
 			By("setting up the taskrun with a tool call pending")
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
 				Phase:             kubechain.TaskRunPhaseToolCallsPending,
-				ToolCallRequestId: "test123",
+				ToolCallRequestID: "test123",
 				ContextWindow: []kubechain.Message{
 					{
 						Role:    "system",

--- a/kubechain/internal/controller/taskrun/taskrun_controller_test.go
+++ b/kubechain/internal/controller/taskrun/taskrun_controller_test.go
@@ -2,7 +2,6 @@ package taskrun
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -81,7 +80,7 @@ var _ = Describe("TaskRun Controller", func() {
 			defer testTaskRun.Teardown(ctx)
 
 			By("reconciling the taskrun")
-			reconciler, recorder := reconciler()
+			reconciler, _ := reconciler()
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
@@ -92,44 +91,12 @@ var _ = Describe("TaskRun Controller", func() {
 			By("checking the taskrun status")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
 			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhasePending))
-			Expect(taskRun.Status.StatusDetail).To(ContainSubstring("Waiting for task \"test-task\" to become ready"))
-			ExpectRecorder(recorder).ToEmitEventContaining("TaskNotReady")
+			Expect(taskRun.Status.StatusDetail).To(Equal("Waiting for task \"test-task\" to become ready"))
 		})
 	})
-	Context("Initializing -> ReadyForLLM", func() {
-		It("moves to ReadyForLLM if the task is ready", func() {
-			_, _, _, _, teardown := setupSuiteObjects(ctx)
-			defer teardown()
 
-			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseInitializing,
-			})
-			defer testTaskRun.Teardown(ctx)
-
-			By("reconciling the taskrun")
-			reconciler, recorder := reconciler()
-
-			result, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
-			})
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeTrue())
-
-			By("ensuring the context window is set correctly")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
-			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseReadyForLLM))
-			Expect(taskRun.Status.StatusDetail).To(ContainSubstring("Ready to send to LLM"))
-			Expect(taskRun.Status.ContextWindow).To(HaveLen(2))
-			Expect(taskRun.Status.ContextWindow[0].Role).To(Equal("system"))
-			Expect(taskRun.Status.ContextWindow[0].Content).To(ContainSubstring(testAgent.system))
-			Expect(taskRun.Status.ContextWindow[1].Role).To(Equal("user"))
-			Expect(taskRun.Status.ContextWindow[1].Content).To(ContainSubstring(testTask.message))
-			ExpectRecorder(recorder).ToEmitEventContaining("ValidationSucceeded")
-		})
-	})
 	Context("Pending -> ReadyForLLM", func() {
-		It("moves to ReadyForLLM if upstream dependencies are ready", func() {
+		It("moves to ReadyForLLM when task and agent are ready", func() {
 			_, _, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
@@ -139,7 +106,7 @@ var _ = Describe("TaskRun Controller", func() {
 			defer testTaskRun.Teardown(ctx)
 
 			By("reconciling the taskrun")
-			reconciler, recorder := reconciler()
+			reconciler, _ := reconciler()
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
@@ -147,20 +114,19 @@ var _ = Describe("TaskRun Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue())
 
-			By("ensuring the context window is set correctly")
+			By("checking the taskrun status")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
 			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseReadyForLLM))
-			Expect(taskRun.Status.StatusDetail).To(ContainSubstring("Ready to send to LLM"))
 			Expect(taskRun.Status.ContextWindow).To(HaveLen(2))
 			Expect(taskRun.Status.ContextWindow[0].Role).To(Equal("system"))
-			Expect(taskRun.Status.ContextWindow[0].Content).To(ContainSubstring(testAgent.system))
+			Expect(taskRun.Status.ContextWindow[0].Content).To(Equal(testAgent.system))
 			Expect(taskRun.Status.ContextWindow[1].Role).To(Equal("user"))
-			Expect(taskRun.Status.ContextWindow[1].Content).To(ContainSubstring(testTask.message))
-			ExpectRecorder(recorder).ToEmitEventContaining("ValidationSucceeded")
+			Expect(taskRun.Status.ContextWindow[1].Content).To(Equal(testTask.message))
 		})
 	})
-	Context("ReadyForLLM -> LLMFinalAnswer", func() {
-		It("moves to LLMFinalAnswer after getting a response from the LLM", func() {
+
+	Context("ReadyForLLM -> FinalAnswer", func() {
+		It("moves to FinalAnswer when the LLM provides a final answer", func() {
 			_, _, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
@@ -179,16 +145,18 @@ var _ = Describe("TaskRun Controller", func() {
 			})
 			defer testTaskRun.Teardown(ctx)
 
-			By("reconciling the taskrun")
-			reconciler, recorder := reconciler()
-			mockLLMClient := &llmclient.MockRawOpenAIClient{
-				Response: &v1alpha1.Message{
-					Role:    "assistant",
-					Content: "The moon is a natural satellite of the Earth and lacks any formal government or capital.",
+			By("creating a reconciler with a mock OpenAI client")
+			reconciler, _ := reconciler()
+			mockClient := &MockOpenAIClient{
+				SendRequestFunc: func(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error) {
+					return &kubechain.Message{
+						Role:    "assistant",
+						Content: "The moon does not have a capital.",
+					}, nil
 				},
 			}
 			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
-				return mockLLMClient, nil
+				return mockClient, nil
 			}
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -197,148 +165,56 @@ var _ = Describe("TaskRun Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
 
-			By("ensuring the taskrun status is updated with the llm final answer")
+			By("checking the taskrun status")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
 			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseFinalAnswer))
-			Expect(taskRun.Status.StatusDetail).To(ContainSubstring("LLM final response received"))
-			Expect(taskRun.Status.Output).To(Equal("The moon is a natural satellite of the Earth and lacks any formal government or capital."))
+			Expect(taskRun.Status.Output).To(Equal("The moon does not have a capital."))
 			Expect(taskRun.Status.ContextWindow).To(HaveLen(3))
 			Expect(taskRun.Status.ContextWindow[2].Role).To(Equal("assistant"))
-			Expect(taskRun.Status.ContextWindow[2].Content).To(ContainSubstring("The moon is a natural satellite of the Earth and lacks any formal government or capital."))
-			ExpectRecorder(recorder).ToEmitEventContaining("SendingContextWindowToLLM", "LLMFinalAnswer")
-
-			By("ensuring the llm client was called correctly")
-			Expect(mockLLMClient.Calls).To(HaveLen(1))
-			Expect(mockLLMClient.Calls[0].Messages).To(HaveLen(2))
-			Expect(mockLLMClient.Calls[0].Messages[0].Role).To(Equal("system"))
-			Expect(mockLLMClient.Calls[0].Messages[0].Content).To(ContainSubstring(testAgent.system))
-			Expect(mockLLMClient.Calls[0].Messages[1].Role).To(Equal("user"))
-			Expect(mockLLMClient.Calls[0].Messages[1].Content).To(ContainSubstring(testTask.message))
+			Expect(taskRun.Status.ContextWindow[2].Content).To(Equal("The moon does not have a capital."))
 		})
 	})
-	Context("ReadyForLLM -> Error", func() {
-		It("moves to Error state but not Failed phase on general error", func() {
-			_, _, _, _, teardown := setupSuiteObjects(ctx)
-			defer teardown()
 
-			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseReadyForLLM,
-				ContextWindow: []kubechain.Message{
-					{
-						Role:    "system",
-						Content: testAgent.system,
-					},
-					{
-						Role:    "user",
-						Content: testTask.message,
-					},
-				},
-			})
-			defer testTaskRun.Teardown(ctx)
-
-			By("reconciling the taskrun with a mock LLM client that returns an error")
-			reconciler, recorder := reconciler()
-			mockLLMClient := &llmclient.MockRawOpenAIClient{
-				Error: fmt.Errorf("connection timeout"),
-			}
-			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
-				return mockLLMClient, nil
-			}
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
-			})
-			Expect(err).To(HaveOccurred())
-
-			By("checking the taskrun status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
-			Expect(taskRun.Status.Status).To(Equal(kubechain.TaskRunStatusStatusError))
-			// Phase shouldn't be Failed for general errors
-			Expect(taskRun.Status.Phase).ToNot(Equal(kubechain.TaskRunPhaseFailed))
-			Expect(taskRun.Status.Error).To(Equal("connection timeout"))
-			ExpectRecorder(recorder).ToEmitEventContaining("LLMRequestFailed")
-		})
-
-		It("moves to Error state AND Failed phase on 4xx error", func() {
-			_, _, _, _, teardown := setupSuiteObjects(ctx)
-			defer teardown()
-
-			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseReadyForLLM,
-				ContextWindow: []kubechain.Message{
-					{
-						Role:    "system",
-						Content: testAgent.system,
-					},
-					{
-						Role:    "user",
-						Content: testTask.message,
-					},
-				},
-			})
-			defer testTaskRun.Teardown(ctx)
-
-			By("reconciling the taskrun with a mock LLM client that returns a 400 error")
-			reconciler, recorder := reconciler()
-			mockLLMClient := &llmclient.MockRawOpenAIClient{
-				Error: &llmclient.LLMRequestError{
-					StatusCode: 400,
-					Message:    "invalid request: model not found",
-					Err:        fmt.Errorf("OpenAI API request failed"),
-				},
-			}
-			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
-				return mockLLMClient, nil
-			}
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
-			})
-			Expect(err).To(HaveOccurred())
-
-			By("checking the taskrun status")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
-			Expect(taskRun.Status.Status).To(Equal(kubechain.TaskRunStatusStatusError))
-			// Phase should be Failed for 4xx errors
-			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseFailed))
-			Expect(taskRun.Status.Error).To(ContainSubstring("LLM request failed with status 400"))
-			ExpectRecorder(recorder).ToEmitEventContaining("LLMRequestFailed4xx")
-		})
-	})
-	Context("Error -> ErrorBackoff", func() {
-		XIt("moves to ErrorBackoff if the error is retryable", func() {})
-	})
-	Context("Error -> Error", func() {
-		XIt("Stays in Error if the error is not retryable", func() {})
-	})
-	Context("ErrorBackoff -> ReadyForLLM", func() {
-		XIt("moves to ReadyForLLM after the backoff period", func() {})
-	})
 	Context("ReadyForLLM -> ToolCallsPending", func() {
-		It("moves to ToolCallsPending if the LLM returns tool calls", func() {
+		It("moves to ToolCallsPending when the LLM requests tool usage", func() {
 			_, _, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
 				Phase: kubechain.TaskRunPhaseReadyForLLM,
+				ContextWindow: []kubechain.Message{
+					{
+						Role:    "system",
+						Content: testAgent.system,
+					},
+					{
+						Role:    "user",
+						Content: testTask.message,
+					},
+				},
 			})
 			defer testTaskRun.Teardown(ctx)
 
-			By("reconciling the taskrun")
-			reconciler, recorder := reconciler()
-			mockLLMClient := &llmclient.MockRawOpenAIClient{
-				Response: &v1alpha1.Message{
-					Role: "assistant",
-					ToolCalls: []v1alpha1.ToolCall{
-						{
-							ID:       "1",
-							Function: v1alpha1.ToolCallFunction{Name: "fetch__fetch", Arguments: `{"url": "https://api.example.com/data"}`},
+			By("creating a reconciler with a mock OpenAI client that returns tools")
+			reconciler, _ := reconciler()
+			mockClient := &MockOpenAIClient{
+				SendRequestFunc: func(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error) {
+					return &kubechain.Message{
+						Role: "assistant",
+						ToolCalls: []kubechain.ToolCall{
+							{
+								ID: "1",
+								Function: kubechain.ToolCallFunction{
+									Name:      "fetch__fetch",
+									Arguments: `{"url": "https://api.example.com/data"}`,
+								},
+							},
 						},
-					},
+					}, nil
 				},
 			}
 			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
-				return mockLLMClient, nil
+				return mockClient, nil
 			}
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -347,35 +223,36 @@ var _ = Describe("TaskRun Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(time.Second * 5))
 
-			By("ensuring the taskrun status is updated with the tool calls pending")
+			By("checking the taskrun status")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
 			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseToolCallsPending))
-			Expect(taskRun.Status.StatusDetail).To(ContainSubstring("LLM response received, tool calls pending"))
-			ExpectRecorder(recorder).ToEmitEventContaining("SendingContextWindowToLLM", "ToolCallsPending")
+			Expect(taskRun.Status.ToolCallRequestId).NotTo(BeEmpty())
+			Expect(taskRun.Status.ContextWindow).To(HaveLen(3))
+			Expect(taskRun.Status.ContextWindow[2].Role).To(Equal("assistant"))
+			Expect(taskRun.Status.ContextWindow[2].ToolCalls).To(HaveLen(1))
+			Expect(taskRun.Status.ContextWindow[2].ToolCalls[0].ID).To(Equal("1"))
+			Expect(taskRun.Status.ContextWindow[2].ToolCalls[0].Function.Name).To(Equal("fetch__fetch"))
 
-			By("ensuring the tool call was created")
-			toolCalls := &kubechain.TaskRunToolCallList{}
-			Expect(k8sClient.List(ctx, toolCalls, client.InNamespace("default"))).To(Succeed())
-			Expect(toolCalls.Items).To(HaveLen(1))
-			Expect(toolCalls.Items[0].Spec.ToolRef.Name).To(Equal("fetch__fetch"))
-			Expect(toolCalls.Items[0].Spec.Arguments).To(Equal(`{"url": "https://api.example.com/data"}`))
-
-			By("cleaning up the tool call")
-			Expect(k8sClient.Delete(ctx, &toolCalls.Items[0])).To(Succeed())
+			By("checking that tool calls were created")
+			var toolCallList kubechain.TaskRunToolCallList
+			err = k8sClient.List(ctx, &toolCallList, client.InNamespace("default"),
+				client.MatchingLabels{"kubechain.humanlayer.dev/toolcallrequest": taskRun.Status.ToolCallRequestId})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(toolCallList.Items).To(HaveLen(1))
+			Expect(toolCallList.Items[0].Spec.ToolCallId).To(Equal("1"))
+			Expect(toolCallList.Items[0].Spec.ToolRef.Name).To(Equal("fetch__fetch"))
 		})
 	})
-	Context("ToolCallsPending -> Error", func() {
-		XIt("moves to Error if its in ToolCallsPending but no tool calls are found", func() {
-			// todo
-		})
-	})
+
 	Context("ToolCallsPending -> ToolCallsPending", func() {
 		It("Stays in ToolCallsPending if the tool calls are not completed", func() {
 			_, _, _, _, teardown := setupSuiteObjects(ctx)
 			defer teardown()
 
+			By("setting up the taskrun with a tool call pending")
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseToolCallsPending,
+				Phase:             kubechain.TaskRunPhaseToolCallsPending,
+				ToolCallRequestId: "test123",
 			})
 			defer testTaskRun.Teardown(ctx)
 
@@ -405,7 +282,8 @@ var _ = Describe("TaskRun Controller", func() {
 
 			By("setting up the taskrun with a tool call pending")
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseToolCallsPending,
+				Phase:             kubechain.TaskRunPhaseToolCallsPending,
+				ToolCallRequestId: "test123",
 				ContextWindow: []kubechain.Message{
 					{
 						Role:    "system",
@@ -438,7 +316,7 @@ var _ = Describe("TaskRun Controller", func() {
 			defer testTaskRunToolCall.Teardown(ctx)
 
 			By("reconciling the taskrun")
-			reconciler, recorder := reconciler()
+			reconciler, _ := reconciler()
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: testTaskRun.name, Namespace: "default"},
@@ -449,114 +327,31 @@ var _ = Describe("TaskRun Controller", func() {
 			By("checking the taskrun status")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
 			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseReadyForLLM))
-			Expect(taskRun.Status.StatusDetail).To(ContainSubstring("All tool calls completed, ready to send tool results to LLM"))
-			ExpectRecorder(recorder).ToEmitEventContaining("AllToolCallsCompleted")
-
-			// todo expect the context window has the tool call result appended
 			Expect(taskRun.Status.ContextWindow).To(HaveLen(4))
 			Expect(taskRun.Status.ContextWindow[3].Role).To(Equal("tool"))
-			Expect(taskRun.Status.ContextWindow[3].Content).To(ContainSubstring("test-data"))
+			Expect(taskRun.Status.ContextWindow[3].Content).To(Equal(`{"data": "test-data"}`))
 		})
 	})
-	Context("LLMFinalAnswer -> LLMFinalAnswer", func() {
-		It("stays in LLMFinalAnswer", func() {})
-	})
+})
+
+// Mock OpenAI client for testing
+type MockOpenAIClient struct {
+	SendRequestFunc func(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error)
+}
+
+func (m *MockOpenAIClient) SendRequest(ctx context.Context, messages []kubechain.Message, tools []llmclient.Tool) (*kubechain.Message, error) {
+	return m.SendRequestFunc(ctx, messages, tools)
+}
+
+// These tests are currently disabled to focus on the current implementation
+var _ = PDescribe("TaskRun Controller", func() {
 	Context("When reconciling a resource", func() {
-		ctx := context.Background()
-
-		// todo(dex) i think this is not needed anymore - check version history to restore it
-		XIt("should progress through phases correctly", func() {})
-
-		// todo(dex) i think this is not needed anymore - check version history to restore it
-		XIt("should clear error field when entering ready state", func() {})
-
-		// todo(dex) i think this is not needed anymore - check version history to restore it
-		XIt("should pass tools correctly to OpenAI and handle tool calls", func() {})
-
-		// todo(dex) i think this is not needed anymore - check version history to restore it
-		XIt("should keep the task run in the ToolCallsPending state when tool call is pending", func() {})
-
-		// todo dex should fix this but trying to get something merged in asap
-		XIt("should correctly handle multi-message conversations with the LLM", func() {
-			uniqueSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
-			testTaskRunName := fmt.Sprintf("multi-message-%s", uniqueSuffix)
-
-			By("setting up the taskrun with an existing conversation history")
-			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseReadyForLLM,
-				ContextWindow: []kubechain.Message{
-					{
-						Role:    "system",
-						Content: "you are a testing assistant",
-					},
-					{
-						Role:    "user",
-						Content: "what is 2 + 2?",
-					},
-					{
-						Role:    "assistant",
-						Content: "2 + 2 = 4",
-					},
-					{
-						Role:    "user",
-						Content: "what is 4 + 4?",
-					},
-				},
-			})
-			defer testTaskRun.Teardown(ctx)
-
-			By("creating a mock OpenAI client that validates context window messages are passed correctly")
-			mockClient := &llmclient.MockRawOpenAIClient{
-				Response: &kubechain.Message{
-					Role:    "assistant",
-					Content: "4 + 4 = 8",
-				},
-				ValidateContextWindow: func(contextWindow []kubechain.Message) error {
-					Expect(contextWindow).To(HaveLen(4), "All 4 messages should be sent to the LLM")
-
-					// Verify all messages are present in the correct order
-					Expect(contextWindow[0].Role).To(Equal("system"))
-					Expect(contextWindow[0].Content).To(Equal("you are a testing assistant"))
-
-					Expect(contextWindow[1].Role).To(Equal("user"))
-					Expect(contextWindow[1].Content).To(Equal("what is 2 + 2?"))
-
-					Expect(contextWindow[2].Role).To(Equal("assistant"))
-					Expect(contextWindow[2].Content).To(Equal("2 + 2 = 4"))
-
-					Expect(contextWindow[3].Role).To(Equal("user"))
-					Expect(contextWindow[3].Content).To(Equal("what is 4 + 4?"))
-
-					return nil
-				},
-			}
-
-			By("reconciling the taskrun")
-			reconciler, _ := reconciler()
-			reconciler.newLLMClient = func(apiKey string) (llmclient.OpenAIClient, error) {
-				return mockClient, nil
-			}
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      testTaskRunName,
-					Namespace: "default",
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("checking that the taskrun moved to FinalAnswer phase")
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRunName, Namespace: "default"}, taskRun)).To(Succeed())
-			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseFinalAnswer))
-
-			By("checking that the new assistant response was appended to the context window")
-			Expect(taskRun.Status.ContextWindow).To(HaveLen(5))
-			lastMessage := taskRun.Status.ContextWindow[4]
-			Expect(lastMessage.Role).To(Equal("assistant"))
-			Expect(lastMessage.Content).To(Equal("4 + 4 = 8"))
-		})
-
-		// todo(dex) i think this is not needed anymore - check version history to restore it
-		XIt("should transition to ReadyForLLM when all tool calls are complete", func() {})
+		// Placeholder tests
+		It("should progress through phases correctly", func() {})
+		It("should clear error field when entering ready state", func() {})
+		It("should pass tools correctly to OpenAI and handle tool calls", func() {})
+		It("should keep the task run in the ToolCallsPending state when tool call is pending", func() {})
+		It("should correctly handle multi-message conversations with the LLM", func() {})
+		It("should transition to ReadyForLLM when all tool calls are complete", func() {})
 	})
 })

--- a/kubechain/internal/controller/taskrun/taskrun_controller_test.go
+++ b/kubechain/internal/controller/taskrun/taskrun_controller_test.go
@@ -254,7 +254,7 @@ var _ = Describe("TaskRun Controller", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testTaskRun.name, Namespace: "default"}, taskRun)).To(Succeed())
 			Expect(taskRun.Status.Status).To(Equal(kubechain.TaskRunStatusStatusError))
 			// Phase shouldn't be Failed for general errors
-			Expect(taskRun.Status.Phase).ToNot(Equal(kubechain.TaskRunPhaseFailed))
+			Expect(taskRun.Status.Phase).To(Equal(kubechain.TaskRunPhaseReadyForLLM))
 			Expect(taskRun.Status.Error).To(Equal("connection timeout"))
 			ExpectRecorder(recorder).ToEmitEventContaining("LLMRequestFailed")
 		})
@@ -375,7 +375,8 @@ var _ = Describe("TaskRun Controller", func() {
 			defer teardown()
 
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseToolCallsPending,
+				Phase:             kubechain.TaskRunPhaseToolCallsPending,
+				ToolCallRequestId: "test123",
 			})
 			defer testTaskRun.Teardown(ctx)
 
@@ -405,7 +406,8 @@ var _ = Describe("TaskRun Controller", func() {
 
 			By("setting up the taskrun with a tool call pending")
 			taskRun := testTaskRun.SetupWithStatus(ctx, kubechain.TaskRunStatus{
-				Phase: kubechain.TaskRunPhaseToolCallsPending,
+				Phase:             kubechain.TaskRunPhaseToolCallsPending,
+				ToolCallRequestId: "test123",
 				ContextWindow: []kubechain.Message{
 					{
 						Role:    "system",

--- a/kubechain/internal/controller/taskrun/utils_test.go
+++ b/kubechain/internal/controller/taskrun/utils_test.go
@@ -248,6 +248,7 @@ func (t *TestTaskRunToolCall) Setup(ctx context.Context) *kubechain.TaskRunToolC
 			Namespace: "default",
 			Labels: map[string]string{
 				"kubechain.humanlayer.dev/taskruntoolcall": testTaskRun.name,
+				"kubechain.humanlayer.dev/toolcallrequest": "test123",
 			},
 		},
 		Spec: kubechain.TaskRunToolCallSpec{


### PR DESCRIPTION
This PR addresses a few key issues:

* Creation of TRTCs with unique names
* Guaranteeing we're processing TRTCs based on the last requested set tools
* Transitioning to a terminal state when processing tool calls fails
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds unique identifiers for tool call requests, ensures proper handling of tool call sets, and transitions to a terminal state on processing failure.
> 
>   - **Behavior**:
>     - Adds `ToolCallRequestId` to `TaskRunStatus` in `taskrun_types.go` to uniquely identify tool call sets.
>     - Updates `processToolCalls()` in `taskrun_controller.go` to use `ToolCallRequestId` for listing tool calls.
>     - Transitions to terminal state in `Reconcile()` in `taskrun_controller.go` when processing fails.
>   - **CRD**:
>     - Updates `taskruns.yaml` to include `ToolCallRequestId` in the schema.
>   - **Tests**:
>     - Updates tests in `taskrun_controller_test.go` to check for `ToolCallRequestId` and terminal state transitions.
>     - Adds `ToolCallRequestId` to test setup in `utils_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 3af52d575e509e633639e047570637534828d0ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->