### PR TITLE
Add ToolType to TRTC

### DIFF
--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -26,6 +26,10 @@ type TaskRunToolCallSpec struct {
 	// +kubebuilder:validation:Required
 	ToolRef LocalObjectReference `json:"toolRef"`
 
+	// ToolType identifies the type of the tool (Standard, MCP, HumanContact)
+	// +optional
+	ToolType ToolType `json:"toolType,omitempty"`
+
 	// Arguments contains the arguments for the tool call
 	// +kubebuilder:validation:Required
 	Arguments string `json:"arguments"`

--- a/kubechain/api/v1alpha1/tool_types.go
+++ b/kubechain/api/v1alpha1/tool_types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ToolType defines the type of a tool in the system
-// +kubebuilder:validation:Enum=Standard;MCP;HumanContact
+// +kubebuilder:validation:Enum=MCP;HumanContact
 type ToolType string
 
 const (

--- a/kubechain/api/v1alpha1/tool_types.go
+++ b/kubechain/api/v1alpha1/tool_types.go
@@ -5,6 +5,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// ToolType defines the type of a tool in the system
+// +kubebuilder:validation:Enum=Standard;MCP;HumanContact
+type ToolType string
+
+const (
+	// ToolTypeMCP indicates a tool provided by an MCP server
+	ToolTypeMCP ToolType = "MCP"
+	// ToolTypeHumanContact indicates a tool for human interaction
+	ToolTypeHumanContact ToolType = "HumanContact"
+)
+
 // ToolSpec defines the desired state of Tool
 type ToolSpec struct {
 	// Name is used for inline/function tools (optional if the object name is used).

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -91,7 +91,6 @@ spec:
                 description: ToolType identifies the type of the tool (Standard, MCP,
                   HumanContact)
                 enum:
-                - Standard
                 - MCP
                 - HumanContact
                 type: string

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -87,6 +87,14 @@ spec:
                 required:
                 - name
                 type: object
+              toolType:
+                description: ToolType identifies the type of the tool (Standard, MCP,
+                  HumanContact)
+                enum:
+                - Standard
+                - MCP
+                - HumanContact
+                type: string
             required:
             - arguments
             - taskRef

--- a/kubechain/config/manager/kustomization.yaml
+++ b/kubechain/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/humanlayer/smallchain
-  newTag: v0.2.0
+  newName: controller
+  newTag: "202504071305"

--- a/kubechain/internal/adapters/mcp_adapter.go
+++ b/kubechain/internal/adapters/mcp_adapter.go
@@ -10,7 +10,7 @@ import (
 
 // ConvertMCPToolsToLLMClientTools converts KubeChain MCPTool objects to LLM client tool format
 func ConvertMCPToolsToLLMClientTools(mcpTools []kubechainv1alpha1.MCPTool, serverName string) []llmclient.Tool {
-	var clientTools = make([]llmclient.Tool, 0, len(mcpTools))
+	clientTools := make([]llmclient.Tool, 0, len(mcpTools))
 
 	for _, tool := range mcpTools {
 		// Create a function definition
@@ -41,8 +41,9 @@ func ConvertMCPToolsToLLMClientTools(mcpTools []kubechainv1alpha1.MCPTool, serve
 
 		// Create the tool with the function definition
 		clientTools = append(clientTools, llmclient.Tool{
-			Type:     "function",
-			Function: toolFunction,
+			Type:              "function",
+			Function:          toolFunction,
+			KubechainToolType: kubechainv1alpha1.ToolTypeMCP,
 		})
 	}
 

--- a/kubechain/internal/controller/task/task_controller.go
+++ b/kubechain/internal/controller/task/task_controller.go
@@ -320,7 +320,7 @@ func (r *TaskReconciler) endTaskSpan(ctx context.Context, task *kubechain.Task, 
 // collectTools collects all tools from the agent's MCP servers
 func (r *TaskReconciler) collectTools(ctx context.Context, agent *kubechain.Agent) []llmclient.Tool {
 	logger := log.FromContext(ctx)
-	var tools []llmclient.Tool
+	tools := make([]llmclient.Tool, 0)
 
 	// Get tools from MCP manager
 	mcpTools := r.MCPManager.GetToolsForAgent(agent)
@@ -331,7 +331,6 @@ func (r *TaskReconciler) collectTools(ctx context.Context, agent *kubechain.Agen
 	}
 
 	// Convert HumanContactChannel tools to LLM tools
-
 	for _, validChannel := range agent.Status.ValidHumanContactChannels {
 		channel := &v1alpha1.ContactChannel{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: agent.Namespace, Name: validChannel.Name}, channel); err != nil {

--- a/kubechain/internal/controller/task/task_controller.go
+++ b/kubechain/internal/controller/task/task_controller.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	kubechain "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -317,7 +318,8 @@ func (r *TaskReconciler) endTaskSpan(ctx context.Context, task *kubechain.Task, 
 }
 
 // collectTools collects all tools from the agent's MCP servers
-func (r *TaskReconciler) collectTools(agent *kubechain.Agent) []llmclient.Tool {
+func (r *TaskReconciler) collectTools(ctx context.Context, agent *kubechain.Agent) []llmclient.Tool {
+	logger := log.FromContext(ctx)
 	var tools []llmclient.Tool
 
 	// Get tools from MCP manager
@@ -326,6 +328,21 @@ func (r *TaskReconciler) collectTools(agent *kubechain.Agent) []llmclient.Tool {
 	// Convert MCP tools to LLM tools
 	for _, mcpTool := range mcpTools {
 		tools = append(tools, adapters.ConvertMCPToolsToLLMClientTools([]kubechain.MCPTool{mcpTool}, mcpTool.Name)...)
+	}
+
+	// Convert HumanContactChannel tools to LLM tools
+
+	for _, validChannel := range agent.Status.ValidHumanContactChannels {
+		channel := &v1alpha1.ContactChannel{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: agent.Namespace, Name: validChannel.Name}, channel); err != nil {
+			logger.Error(err, "Failed to get ContactChannel", "name", validChannel.Name)
+			continue
+		}
+
+		// Convert to LLM client format
+		clientTool := llmclient.ToolFromContactChannel(*channel)
+		tools = append(tools, *clientTool)
+		logger.Info("Added human contact channel tool", "name", channel.Name, "type", channel.Spec.Type)
 	}
 
 	return tools
@@ -363,7 +380,7 @@ func (r *TaskReconciler) createLLMRequestSpan(ctx context.Context, task *kubecha
 }
 
 // processLLMResponse processes the LLM response and updates the Task status
-func (r *TaskReconciler) processLLMResponse(ctx context.Context, output *kubechain.Message, task *kubechain.Task, statusUpdate *kubechain.Task) (ctrl.Result, error) {
+func (r *TaskReconciler) processLLMResponse(ctx context.Context, output *kubechain.Message, task *kubechain.Task, statusUpdate *kubechain.Task, tools []llmclient.Tool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if output.Content != "" {
@@ -407,13 +424,13 @@ func (r *TaskReconciler) processLLMResponse(ctx context.Context, output *kubecha
 			return ctrl.Result{}, err
 		}
 
-		return r.createToolCalls(ctx, task, statusUpdate, output.ToolCalls)
+		return r.createToolCalls(ctx, task, statusUpdate, output.ToolCalls, tools)
 	}
 	return ctrl.Result{}, nil
 }
 
 // createToolCalls creates TaskRunToolCall objects for each tool call
-func (r *TaskReconciler) createToolCalls(ctx context.Context, task *kubechain.Task, statusUpdate *kubechain.Task, toolCalls []kubechain.ToolCall) (ctrl.Result, error) {
+func (r *TaskReconciler) createToolCalls(ctx context.Context, task *kubechain.Task, statusUpdate *kubechain.Task, toolCalls []kubechain.ToolCall, tools []llmclient.Tool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if statusUpdate.Status.ToolCallRequestID == "" {
@@ -422,9 +439,17 @@ func (r *TaskReconciler) createToolCalls(ctx context.Context, task *kubechain.Ta
 		return ctrl.Result{}, err
 	}
 
+	// Create a map of tool name to tool type for quick lookup
+	toolTypeMap := make(map[string]v1alpha1.ToolType)
+	for _, tool := range tools {
+		toolTypeMap[tool.Function.Name] = tool.KubechainToolType
+	}
+
 	// For each tool call, create a new TaskRunToolCall with a unique name using the ToolCallRequestID
 	for i, tc := range toolCalls {
 		newName := fmt.Sprintf("%s-%s-tc-%02d", statusUpdate.Name, statusUpdate.Status.ToolCallRequestID, i+1)
+		toolType := toolTypeMap[tc.Function.Name]
+
 		newTRTC := &kubechain.TaskRunToolCall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newName,
@@ -451,6 +476,7 @@ func (r *TaskReconciler) createToolCalls(ctx context.Context, task *kubechain.Ta
 				ToolRef: kubechain.LocalObjectReference{
 					Name: tc.Function.Name,
 				},
+				ToolType:  toolTypeMap[tc.Function.Name],
 				Arguments: tc.Function.Arguments,
 			},
 		}
@@ -458,7 +484,7 @@ func (r *TaskReconciler) createToolCalls(ctx context.Context, task *kubechain.Ta
 			logger.Error(err, "Failed to create TaskRunToolCall", "name", newName)
 			return ctrl.Result{}, err
 		}
-		logger.Info("Created TaskRunToolCall", "name", newName, "requestId", statusUpdate.Status.ToolCallRequestID)
+		logger.Info("Created TaskRunToolCall", "name", newName, "requestId", statusUpdate.Status.ToolCallRequestID, "toolType", toolType)
 		r.recorder.Event(task, corev1.EventTypeNormal, "ToolCallCreated", "Created TaskRunToolCall "+newName)
 	}
 	return ctrl.Result{RequeueAfter: time.Second * 5}, nil
@@ -544,7 +570,7 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Step 7: Collect tools from all sources
-	tools := r.collectTools(agent)
+	tools := r.collectTools(ctx, agent)
 
 	r.recorder.Event(&task, corev1.EventTypeNormal, "SendingContextWindowToLLM", "Sending context window to LLM")
 
@@ -598,7 +624,7 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	logger.V(3).Info("Processing LLM response")
 	// Step 9: Process LLM response
 	var llmResult ctrl.Result
-	llmResult, err = r.processLLMResponse(ctx, output, &task, statusUpdate)
+	llmResult, err = r.processLLMResponse(ctx, output, &task, statusUpdate, tools)
 	if err != nil {
 		logger.Error(err, "Failed to process LLM response")
 		statusUpdate.Status.Status = kubechain.TaskStatusTypeError

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller.go
@@ -123,18 +123,18 @@ func (r *TaskRunToolCallReconciler) updateTaskRunToolCall(ctx context.Context, w
 
 // isMCPTool checks if a tool is an MCP tool and extracts the server name and actual tool name
 func isMCPTool(trtc *kubechainv1alpha1.TaskRunToolCall) (serverName string, actualToolName string, isMCP bool) {
-	// First check if we have a tool type field
-	if trtc.Spec.ToolType == kubechainv1alpha1.ToolTypeMCP {
-		// For MCP tools, we still need to parse the name to get the server and tool parts
-		parts := strings.Split(trtc.Spec.ToolRef.Name, "__")
-		if len(parts) == 2 {
-			return parts[0], parts[1], true
-		}
-		// This shouldn't happen if toolType is set correctly, but just in case
-		return "", trtc.Spec.ToolRef.Name, true
+	// If this isn't an MCP, no server name__tool_name to split
+	if trtc.Spec.ToolType != kubechainv1alpha1.ToolTypeMCP {
+		return "", trtc.Spec.ToolRef.Name, false
 	}
 
-	return "", trtc.Spec.ToolRef.Name, false
+	// For MCP tools, we still need to parse the name to get the server and tool parts
+	parts := strings.Split(trtc.Spec.ToolRef.Name, "__")
+	if len(parts) == 2 {
+		return parts[0], parts[1], true
+	}
+	// This shouldn't happen if toolType is set correctly, but just in case
+	return "", trtc.Spec.ToolRef.Name, true
 }
 
 // executeMCPTool executes a tool call on an MCP server

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -175,6 +175,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 				name:      "test-mcp-no-approval-trtc",
 				toolName:  tool.Spec.Name,
 				arguments: `{"a": 2, "b": 3}`,
+				toolType:  kubechainv1alpha1.ToolTypeMCP,
 			}
 			trtc := taskRunToolCall.SetupWithStatus(ctx, kubechainv1alpha1.TaskRunToolCallStatus{
 				Phase:        kubechainv1alpha1.TaskRunToolCallPhasePending,
@@ -182,6 +183,7 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 				StatusDetail: "Setup complete",
 				StartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
 			})
+
 			defer taskRunToolCall.Teardown(ctx)
 
 			By("reconciling the taskruntoolcall that uses MCP tool without approval")

--- a/kubechain/internal/controller/taskruntoolcall/utils_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/utils_test.go
@@ -147,6 +147,7 @@ type TestTaskRunToolCall struct {
 	name            string
 	toolName        string
 	arguments       string
+	toolType        kubechainv1alpha1.ToolType
 	taskRunToolCall *kubechainv1alpha1.TaskRunToolCall
 }
 
@@ -172,6 +173,7 @@ func (t *TestTaskRunToolCall) Setup(ctx context.Context) *kubechainv1alpha1.Task
 			ToolRef: kubechainv1alpha1.LocalObjectReference{
 				Name: t.toolName,
 			},
+			ToolType:  t.toolType,
 			Arguments: t.arguments,
 		},
 	}
@@ -431,6 +433,7 @@ func setupTestApprovalResources(ctx context.Context, config *SetupTestApprovalCo
 		name:      name,
 		toolName:  mcpTool.Spec.Name,
 		arguments: args,
+		toolType:  kubechainv1alpha1.ToolTypeMCP,
 	}
 
 	status := kubechainv1alpha1.TaskRunToolCallStatus{

--- a/kubechain/internal/llmclient/llm_client.go
+++ b/kubechain/internal/llmclient/llm_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
 )
 
@@ -33,6 +34,9 @@ func (e *LLMRequestError) Unwrap() error {
 type Tool struct {
 	Type     string       `json:"type"`
 	Function ToolFunction `json:"function"`
+	// KubechainToolType represents the Kubechain-specific type of tool (MCP, HumanContact)
+	// This field is not sent to the LLM API but is used internally for tool identification
+	KubechainToolType v1alpha1.ToolType `json:"-"`
 }
 
 // ToolFunction contains the function details
@@ -52,4 +56,45 @@ type ToolFunctionParameters struct {
 	Type       string                           `json:"type"`
 	Properties map[string]ToolFunctionParameter `json:"properties"`
 	Required   []string                         `json:"required,omitempty"`
+}
+
+// FromContactChannel creates a Tool from a ContactChannel resource
+func ToolFromContactChannel(channel v1alpha1.ContactChannel) *Tool {
+	// Create base parameters structure for human contact tools
+	params := ToolFunctionParameters{
+		Type: "object",
+		Properties: map[string]ToolFunctionParameter{
+			"message": {Type: "string"},
+		},
+		Required: []string{"message"},
+	}
+
+	var description string
+	var name string
+
+	// Customize based on channel type
+	switch channel.Spec.Type {
+	case v1alpha1.ContactChannelTypeEmail:
+		name = fmt.Sprintf("human_contact_email_%s", channel.Name)
+		description = channel.Spec.Email.ContextAboutUser
+
+	case v1alpha1.ContactChannelTypeSlack:
+		name = fmt.Sprintf("human_contact_slack_%s", channel.Name)
+		description = channel.Spec.Slack.ContextAboutChannelOrUser
+
+	default:
+		name = fmt.Sprintf("human_contact_%s", channel.Name)
+		description = fmt.Sprintf("Contact a human via %s channel", channel.Spec.Type)
+	}
+
+	// Create the Tool
+	return &Tool{
+		Type: "function",
+		Function: ToolFunction{
+			Name:        name,
+			Description: description,
+			Parameters:  params,
+		},
+		KubechainToolType: v1alpha1.ToolTypeHumanContact, // Set as HumanContact type
+	}
 }


### PR DESCRIPTION
Replaces #57, via that original request:

> Why are we doing this - Today when we create TRTCs, they can be sourced from other normal tools or "MCP" tools and we differentiate between these largely based on the name of the tool. However, as well look to add tools that will require human input and subsequently affect the TRTC flow/statuses/etc. we need some way to differentiate. This PR adds ToolType to the TRTC to allow for that differentiation.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `ToolType` to `TaskRunToolCallSpec` and updates logic to handle different tool types, including MCP and HumanContact.
> 
>   - **Behavior**:
>     - Adds `ToolType` field to `TaskRunToolCallSpec` in `taskruntoolcall_types.go` to specify tool types (Standard, MCP, HumanContact).
>     - Updates `taskruntoolcall_controller.go` to handle `ToolType` in tool execution logic.
>     - Modifies `task_controller.go` to collect tools based on `ToolType`.
>   - **Models**:
>     - Defines `ToolType` enum in `tool_types.go` with values: Standard, MCP, HumanContact.
>   - **CRD**:
>     - Updates `kubechain.humanlayer.dev_taskruntoolcalls.yaml` to include `ToolType` in the schema.
>   - **Tests**:
>     - Updates `taskruntoolcall_controller_test.go` and `utils_test.go` to test new `ToolType` logic.
>   - **Misc**:
>     - Changes image tag in `kustomization.yaml` to `202504071305`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=humanlayer%2Fkubechain&utm_source=github&utm_medium=referral)<sup> for 9ab9eee3e8f1ace4b2331b7a47f32dd4d952b0ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->