### PR TITLE
Implement Human ContactChannel integration for using humans as tools during resolution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,6 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/kubechain/cmd/main.go",
-      "args": [],
       "env": {
         "KUBECONFIG": "${env:HOME}/.kube/config"
       }

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -4,6 +4,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ToolType defines the type of a tool in the system
+// +kubebuilder:validation:Enum=MCP;HumanContact
+type ToolType string
+
+const (
+	// ToolTypeMCP indicates a tool provided by an MCP server
+	ToolTypeMCP ToolType = "MCP"
+	// ToolTypeHumanContact indicates a tool for human interaction
+	ToolTypeHumanContact ToolType = "HumanContact"
+)
+
 type TaskRunToolCallStatusType string
 
 const (
@@ -78,7 +89,7 @@ type TaskRunToolCallStatus struct {
 }
 
 // TaskRunToolCallPhase represents the phase of a TaskRunToolCall
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval;ToolCallRejected
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;AwaitingHumanInput;AwaitingSubAgent;AwaitingHumanApproval;ReadyToExecuteApprovedTool;ErrorRequestingHumanApproval;ToolCallRejected;ErrorRequestingHumanInput
 type TaskRunToolCallPhase string
 
 const (
@@ -102,6 +113,8 @@ const (
 	TaskRunToolCallPhaseErrorRequestingHumanApproval TaskRunToolCallPhase = "ErrorRequestingHumanApproval"
 	// TaskRunToolCallPhaseToolCallRejected indicates the tool call was rejected by human approval
 	TaskRunToolCallPhaseToolCallRejected TaskRunToolCallPhase = "ToolCallRejected"
+	// TaskRunToolCallPhaseErrorRequestingHumanInput indicates there was an error requesting human input
+	TaskRunToolCallPhaseErrorRequestingHumanInput TaskRunToolCallPhase = "ErrorRequestingHumanInput"
 )
 
 // +kubebuilder:object:root=true

--- a/kubechain/api/v1alpha1/tool_types.go
+++ b/kubechain/api/v1alpha1/tool_types.go
@@ -5,17 +5,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// ToolType defines the type of a tool in the system
-// +kubebuilder:validation:Enum=MCP;HumanContact
-type ToolType string
-
-const (
-	// ToolTypeMCP indicates a tool provided by an MCP server
-	ToolTypeMCP ToolType = "MCP"
-	// ToolTypeHumanContact indicates a tool for human interaction
-	ToolTypeHumanContact ToolType = "HumanContact"
-)
-
 // ToolSpec defines the desired state of Tool
 type ToolSpec struct {
 	// Name is used for inline/function tools (optional if the object name is used).

--- a/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
+++ b/kubechain/config/crd/bases/kubechain.humanlayer.dev_taskruntoolcalls.yaml
@@ -127,6 +127,7 @@ spec:
                 - ReadyToExecuteApprovedTool
                 - ErrorRequestingHumanApproval
                 - ToolCallRejected
+                - ErrorRequestingHumanInput
                 type: string
               ready:
                 description: Ready indicates if the tool call is ready to be executed

--- a/kubechain/internal/controller/task/task_controller.go
+++ b/kubechain/internal/controller/task/task_controller.go
@@ -579,7 +579,10 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		defer childSpan.End()
 	}
 
-	logger.V(3).Info("Sending LLM request")
+	logger.V(1).Info("Sending LLM request",
+		"phase", task.Status.Phase,
+		"status", task.Status.Status)
+
 	// Step 8: Send the prompt to the LLM
 	output, err := llmClient.SendRequest(childCtx, task.Status.ContextWindow, tools)
 	if err != nil {

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -479,6 +479,48 @@ var _ = Describe("TaskRunToolCall Controller", func() {
 		})
 	})
 
+	Context("Ready:Pending -> Ready:AwaitingHumanInput (HumanContact Tool)", func() {
+		It("transitions to Ready:AwaitingHumanInput when ToolType is HumanContact", func() {
+			// Set up resources for human contact
+			trtc, teardown := setupTestHumanContactResources(ctx, nil)
+			defer teardown()
+
+			By("reconciling the taskruntoolcall that uses HumanContact tool")
+			reconciler, recorder := reconciler()
+
+			reconciler.HLClientFactory = &humanlayer.MockHumanLayerClientFactory{
+				ShouldFail:  false,
+				StatusCode:  200,
+				ReturnError: nil,
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      trtc.Name,
+					Namespace: trtc.Namespace,
+				},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Second)) // Should requeue after 5 seconds
+
+			By("checking the taskruntoolcall has AwaitingHumanInput phase and Ready status")
+			updatedTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trtc.Name,
+				Namespace: trtc.Namespace,
+			}, updatedTRTC)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedTRTC.Status.Phase).To(Equal(kubechainv1alpha1.TaskRunToolCallPhaseAwaitingHumanInput))
+			Expect(updatedTRTC.Status.Status).To(Equal(kubechainv1alpha1.TaskRunToolCallStatusTypeReady))
+			Expect(updatedTRTC.Status.StatusDetail).To(ContainSubstring("Waiting for human input via contact channel"))
+
+			By("checking that appropriate events were emitted")
+			utils.ExpectRecorder(recorder).ToEmitEventContaining("AwaitingHumanContact")
+		})
+	})
+
 	Context("Ready:Pending -> Error:ErrorRequestingHumanApproval (MCP Tool)", func() {
 		It("transitions to Error:ErrorRequestingHumanApproval when request to HumanLayer fails", func() {
 			// Note setupTestApprovalResources sets up the MCP server, MCP tool, and TaskRunToolCall

--- a/kubechain/internal/humanlayer/mock_hlclient.go
+++ b/kubechain/internal/humanlayer/mock_hlclient.go
@@ -84,7 +84,6 @@ func (m *MockHumanLayerClientWrapper) SetAPIKey(apiKey string) {
 
 // GetFunctionCallStatus implements HumanLayerClientWrapper
 func (m *MockHumanLayerClientWrapper) GetFunctionCallStatus(ctx context.Context) (*humanlayerapi.FunctionCallOutput, int, error) {
-
 	if m.parent.ShouldReturnApproval {
 		now := time.Now()
 		approved := true
@@ -130,4 +129,14 @@ func (m *MockHumanLayerClientWrapper) RequestApproval(ctx context.Context) (*hum
 
 	// Return a successful mock response
 	return &humanlayerapi.FunctionCallOutput{}, m.parent.StatusCode, nil
+}
+
+// RequestHumanContact implements HumanLayerClientWrapper
+func (m *MockHumanLayerClientWrapper) RequestHumanContact(ctx context.Context, userMsg string) (*humanlayerapi.HumanContactOutput, int, error) {
+	return nil, m.parent.StatusCode, m.parent.ReturnError
+}
+
+// GetHumanContactStatus implements HumanLayerClientWrapper
+func (m *MockHumanLayerClientWrapper) GetHumanContactStatus(ctx context.Context) (*humanlayerapi.HumanContactOutput, int, error) {
+	return nil, m.parent.StatusCode, m.parent.ReturnError
 }

--- a/kubechain/internal/llmclient/llm_client.go
+++ b/kubechain/internal/llmclient/llm_client.go
@@ -70,28 +70,28 @@ func ToolFromContactChannel(channel v1alpha1.ContactChannel) *Tool {
 	}
 
 	var description string
-	var name string
+	// var name string
 
-	// Customize based on channel type
-	switch channel.Spec.Type {
-	case v1alpha1.ContactChannelTypeEmail:
-		name = fmt.Sprintf("human_contact_email_%s", channel.Name)
-		description = channel.Spec.Email.ContextAboutUser
+	// // Customize based on channel type
+	// switch channel.Spec.Type {
+	// case v1alpha1.ContactChannelTypeEmail:
+	// 	name = fmt.Sprintf("human_contact_email_%s", channel.Name)
+	// 	description = channel.Spec.Email.ContextAboutUser
 
-	case v1alpha1.ContactChannelTypeSlack:
-		name = fmt.Sprintf("human_contact_slack_%s", channel.Name)
-		description = channel.Spec.Slack.ContextAboutChannelOrUser
+	// case v1alpha1.ContactChannelTypeSlack:
+	// 	name = fmt.Sprintf("human_contact_slack_%s", channel.Name)
+	// 	description = channel.Spec.Slack.ContextAboutChannelOrUser
 
-	default:
-		name = fmt.Sprintf("human_contact_%s", channel.Name)
-		description = fmt.Sprintf("Contact a human via %s channel", channel.Spec.Type)
-	}
+	// default:
+	// 	name = fmt.Sprintf("human_contact_%s", channel.Name)
+	// 	description = fmt.Sprintf("Contact a human via %s channel", channel.Spec.Type)
+	// }
 
 	// Create the Tool
 	return &Tool{
 		Type: "function",
 		Function: ToolFunction{
-			Name:        name,
+			Name:        channel.Name,
 			Description: description,
 			Parameters:  params,
 		},

--- a/kubechain/internal/llmclient/llm_client.go
+++ b/kubechain/internal/llmclient/llm_client.go
@@ -70,22 +70,6 @@ func ToolFromContactChannel(channel v1alpha1.ContactChannel) *Tool {
 	}
 
 	var description string
-	// var name string
-
-	// // Customize based on channel type
-	// switch channel.Spec.Type {
-	// case v1alpha1.ContactChannelTypeEmail:
-	// 	name = fmt.Sprintf("human_contact_email_%s", channel.Name)
-	// 	description = channel.Spec.Email.ContextAboutUser
-
-	// case v1alpha1.ContactChannelTypeSlack:
-	// 	name = fmt.Sprintf("human_contact_slack_%s", channel.Name)
-	// 	description = channel.Spec.Slack.ContextAboutChannelOrUser
-
-	// default:
-	// 	name = fmt.Sprintf("human_contact_%s", channel.Name)
-	// 	description = fmt.Sprintf("Contact a human via %s channel", channel.Spec.Type)
-	// }
 
 	// Create the Tool
 	return &Tool{


### PR DESCRIPTION
I'm not quite happy just yet with where we're at on this, here are some things that we need to address

- [] - Tests
- [] - HumanInput/RequestApproval flows are extremely similar in a lot of ways and we're doing duplication that's likely room for consolidation
- [] - There's a curious race condition/loop I'm seeing between runs in the `Task` reconciler that looks like 400s to our LLM provider: `2025-04-08T11:47:49-05:00	DEBUG	events	langchain API call failed: API returned unexpected status code: 400: An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_L4XbOAVTfMYK4u9UXrrgcStS	{"type": "Warning", "object": {"kind":"Task","namespace":"default","name":"fetch-task","uid":"25e92668-e7d3-4ca7-9d1d-e3b24faae55b","apiVersion":"kubechain.humanlayer.dev/v1alpha1","resourceVersion":"681182"}, "reason": "LLMRequestFailed"}`. 
- [ ] - Docs Updates